### PR TITLE
feat(garmin): per-timestamp sleep stages from sleepLevels

### DIFF
--- a/dags/pipelines/garmin/constants.py
+++ b/dags/pipelines/garmin/constants.py
@@ -8,7 +8,7 @@ metadata.
 
 import re
 from dataclasses import dataclass
-from enum import Enum
+from enum import Enum, IntEnum
 from typing import Dict, List, Optional
 
 
@@ -330,6 +330,22 @@ GARMIN_DATA_REGISTRY = GarminDataRegistry()
 
 # Dynamically created file types enum based on registered data types.
 GARMIN_FILE_TYPES = _create_garmin_file_types()
+
+
+class SleepStage(IntEnum):
+    """
+    Discrete sleep stage classification used by Garmin Connect.
+
+    Values map to the integer codes found in the SLEEP JSON response under
+    sleepLevels[*].activityLevel. The enum name (e.g. "DEEP") is stored in
+    garmin.sleep_level.stage_label as a denormalized human-readable label.
+    """
+
+    DEEP = 0
+    LIGHT = 1
+    REM = 2
+    AWAKE = 3
+
 
 PR_TYPE_LABELS = {
     1: "Run: 1 km",

--- a/dags/pipelines/garmin/process.py
+++ b/dags/pipelines/garmin/process.py
@@ -1279,10 +1279,12 @@ class GarminProcessor(Processor):
                 continue
             try:
                 stage = SleepStage(int(activity_level))
-            except ValueError:
+            except (ValueError, TypeError):
+                # ValueError: unknown int code. TypeError: activity_level is not
+                # numeric/string (malformed JSON). Both treated as skip.
                 LOGGER.warning(
-                    f"⚠️ Unknown sleep stage code {activity_level} for sleep_id="
-                    f"{sleep_id}; skipping interval."
+                    f"⚠️ Unparseable sleep stage value {activity_level!r} for "
+                    f"sleep_id={sleep_id}; skipping interval."
                 )
                 continue
             level_records.append(

--- a/dags/pipelines/garmin/process.py
+++ b/dags/pipelines/garmin/process.py
@@ -1279,12 +1279,10 @@ class GarminProcessor(Processor):
                 continue
             try:
                 stage = SleepStage(int(activity_level))
-            except (ValueError, TypeError):
-                # ValueError: unknown int code. TypeError: activity_level is not
-                # numeric/string (malformed JSON). Both treated as skip.
+            except ValueError:
                 LOGGER.warning(
-                    f"⚠️ Unparseable sleep stage value {activity_level!r} for "
-                    f"sleep_id={sleep_id}; skipping interval."
+                    f"⚠️ Unknown sleep stage code {activity_level} for sleep_id="
+                    f"{sleep_id}; skipping interval."
                 )
                 continue
             level_records.append(

--- a/dags/pipelines/garmin/process.py
+++ b/dags/pipelines/garmin/process.py
@@ -26,6 +26,7 @@ from dags.pipelines.garmin.constants import (
     GARMIN_DATA_REGISTRY,
     PR_TYPE_LABELS,
     SEMICIRCLES_TO_DEGREES,
+    SleepStage,
 )
 from dags.pipelines.garmin.sqla_models import (
     Acclimation,
@@ -46,6 +47,7 @@ from dags.pipelines.garmin.sqla_models import (
     Respiration,
     RunningAggMetrics,
     Sleep,
+    SleepLevel,
     SleepMovement,
     SleepRestlessMoment,
     SpO2,
@@ -1000,6 +1002,7 @@ class GarminProcessor(Processor):
             return
 
         # Extract and upsert timeseries data.
+        self._process_sleep_level(sleep_data, sleep_id, session)
         self._process_sleep_movement(sleep_data, sleep_id, session)
         self._process_sleep_restless_moments(sleep_data, sleep_id, session)
         self._process_sleep_spo2_data(sleep_data, sleep_id, session)
@@ -1037,6 +1040,14 @@ class GarminProcessor(Processor):
         if sleep_start_gmt_ms is None or sleep_end_gmt_ms is None:
             return None
 
+        # Calendar date is required (NOT NULL with unique constraint on
+        # (user_id, calendar_date)). Trust Garmin's calendarDate as the source of
+        # truth and raise if it's missing rather than silently dropping the row.
+        calendar_date_str = daily_sleep_dto.pop("calendarDate", None)
+        if calendar_date_str is None:
+            raise ValueError("Missing required field 'calendarDate' in dailySleepDTO.")
+        calendar_date = date.fromisoformat(calendar_date_str)
+
         # Remove sleepEndTimestampLocal if present (not used, prevents auto-conversion).
         daily_sleep_dto.pop("sleepEndTimestampLocal", None)
 
@@ -1051,28 +1062,14 @@ class GarminProcessor(Processor):
         offset_seconds = (sleep_start_local - start_ts).total_seconds()
         timezone_offset_hours = offset_seconds / 3600
 
-        # Calendar date is required: it identifies the sleep session day and is used as
-        # the unique key (user_id, calendar_date) for upserts. Trust Garmin's value;
-        # raise if missing so the failure surfaces immediately rather than silently
-        # corrupting downstream queries.
-        calendar_date_str = daily_sleep_dto.pop("calendarDate", None)
-        if not calendar_date_str:
-            raise ValueError(
-                f"Sleep record for user_id={self.user_id} is missing "
-                f"dailySleepDTO.calendarDate; refusing to insert."
-            )
-        calendar_date = date.fromisoformat(calendar_date_str)
-
         # Start building sleep record.
         sleep_record = {
             # Foreign key field.
             "user_id": int(self.user_id),
-            # Non-nullable timestamps.
+            # Non-nullable timestamps and calendar date.
             "start_ts": start_ts,
             "end_ts": end_ts,
             "timezone_offset_hours": timezone_offset_hours,
-            # Non-nullable calendar date (Garmin source of truth for the sleep session
-            # day).
             "calendar_date": calendar_date,
         }
 
@@ -1253,6 +1250,65 @@ class GarminProcessor(Processor):
         else:
             LOGGER.warning("⚠️ No main sleep data found.")
             return None
+
+    def _process_sleep_level(self, sleep_data: dict, sleep_id: int, session: Session):
+        """
+        Process sleep stage classification intervals from sleepLevels array.
+
+        Each interval is a contiguous segment with a single discrete sleep stage (Deep,
+        Light, REM, Awake). Uses INSERT ... ON CONFLICT DO NOTHING on
+        (sleep_id, start_ts), matching the idempotency pattern of the sibling sleep
+        time-series tables.
+
+        :param sleep_data: Complete JSON sleep data (modified by pop()).
+        :param sleep_id: Sleep session ID.
+        :param session: SQLAlchemy Session object.
+        """
+
+        sleep_levels = sleep_data.pop("sleepLevels", [])
+        if not sleep_levels:
+            LOGGER.warning("⚠️ No sleep level data found.")
+            return
+
+        level_records = []
+        for level in sleep_levels:
+            start_gmt_str = level.pop("startGMT", None)
+            end_gmt_str = level.pop("endGMT", None)
+            activity_level = level.pop("activityLevel", None)
+            if start_gmt_str is None or end_gmt_str is None or activity_level is None:
+                continue
+            try:
+                stage = SleepStage(int(activity_level))
+            except ValueError:
+                LOGGER.warning(
+                    f"⚠️ Unknown sleep stage code {activity_level} for sleep_id="
+                    f"{sleep_id}; skipping interval."
+                )
+                continue
+            level_records.append(
+                SleepLevel(
+                    sleep_id=sleep_id,
+                    start_ts=datetime.fromisoformat(start_gmt_str).replace(
+                        tzinfo=timezone.utc
+                    ),
+                    end_ts=datetime.fromisoformat(end_gmt_str).replace(
+                        tzinfo=timezone.utc
+                    ),
+                    stage=stage.value,
+                    stage_label=stage.name,
+                )
+            )
+
+        if level_records:
+            upsert_model_instances(
+                session=session,
+                model_instances=level_records,
+                conflict_columns=["sleep_id", "start_ts"],
+                on_conflict_update=False,
+            )
+            LOGGER.info(f"Processed {len(level_records)} sleep level records.")
+        else:
+            LOGGER.warning("⚠️ No valid sleep level records to insert.")
 
     def _process_sleep_movement(
         self, sleep_data: dict, sleep_id: int, session: Session

--- a/dags/pipelines/garmin/process.py
+++ b/dags/pipelines/garmin/process.py
@@ -10,7 +10,7 @@ and health metrics.
 import json
 import re
 from collections import OrderedDict
-from datetime import datetime, timezone, timedelta
+from datetime import date, datetime, timezone, timedelta
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -1051,6 +1051,18 @@ class GarminProcessor(Processor):
         offset_seconds = (sleep_start_local - start_ts).total_seconds()
         timezone_offset_hours = offset_seconds / 3600
 
+        # Calendar date is required: it identifies the sleep session day and is used as
+        # the unique key (user_id, calendar_date) for upserts. Trust Garmin's value;
+        # raise if missing so the failure surfaces immediately rather than silently
+        # corrupting downstream queries.
+        calendar_date_str = daily_sleep_dto.pop("calendarDate", None)
+        if not calendar_date_str:
+            raise ValueError(
+                f"Sleep record for user_id={self.user_id} is missing "
+                f"dailySleepDTO.calendarDate; refusing to insert."
+            )
+        calendar_date = date.fromisoformat(calendar_date_str)
+
         # Start building sleep record.
         sleep_record = {
             # Foreign key field.
@@ -1059,6 +1071,9 @@ class GarminProcessor(Processor):
             "start_ts": start_ts,
             "end_ts": end_ts,
             "timezone_offset_hours": timezone_offset_hours,
+            # Non-nullable calendar date (Garmin source of truth for the sleep session
+            # day).
+            "calendar_date": calendar_date,
         }
 
         # Remove the id field from JSON (not used: sleep_id is auto-generated).
@@ -1092,7 +1107,6 @@ class GarminProcessor(Processor):
         # Auto-convert other nullable sleep fields to snake_case.
         sleep_fields_nullable = [
             # Basic sleep data.
-            "calendarDate",
             "sleepVersion",
             "ageGroup",
             "respirationVersion",

--- a/dags/pipelines/garmin/sqla_models.py
+++ b/dags/pipelines/garmin/sqla_models.py
@@ -346,13 +346,13 @@ class Sleep(UpsertBase):
     # Foreign key reference.
     user_id = Column(BigInteger, fkey("garmin", "user", "user_id"), nullable=False)
 
-    # Non-nullable timestamps.
+    # Non-nullable timestamps and calendar date.
     start_ts = Column(DateTime(timezone=True), nullable=False)
     end_ts = Column(DateTime(timezone=True), nullable=False)
     timezone_offset_hours = Column(Float, nullable=False)
+    calendar_date = Column(Date, nullable=False)
 
     # Sleep session metadata.
-    calendar_date = Column(Date, nullable=False)
     sleep_version = Column(Integer)
     age_group = Column(String)
     respiration_version = Column(Integer)
@@ -432,6 +432,26 @@ class Sleep(UpsertBase):
     next_sleep_need_history_adj = Column(String)
     next_sleep_need_hrv_adj = Column(String)
     next_sleep_need_nap_adj = Column(String)
+
+
+class SleepLevel(InsertBase):
+    """
+    Sleep stage classification intervals from Garmin Connect sleepLevels array.
+
+    Each row is a contiguous interval during which a single discrete sleep stage
+    (Deep, Light, REM, Awake) was detected. Used to reconstruct the per-night sleep
+    stages timeline shown in the Garmin Connect sleep view.
+
+    Time interval: Variable-length contiguous intervals (one row per stage segment).
+    """
+
+    __tablename__ = "sleep_level"
+
+    sleep_id = Column(Integer, fkey("garmin", "sleep", "sleep_id"), primary_key=True)
+    start_ts = Column(DateTime(timezone=True), primary_key=True)
+    end_ts = Column(DateTime(timezone=True), nullable=False)
+    stage = Column(Integer, nullable=False)
+    stage_label = Column(String, nullable=False)
 
 
 class SleepMovement(InsertBase):

--- a/dags/pipelines/garmin/sqla_models.py
+++ b/dags/pipelines/garmin/sqla_models.py
@@ -352,7 +352,7 @@ class Sleep(UpsertBase):
     timezone_offset_hours = Column(Float, nullable=False)
 
     # Sleep session metadata.
-    calendar_date = Column(String)
+    calendar_date = Column(Date, nullable=False)
     sleep_version = Column(Integer)
     age_group = Column(String)
     respiration_version = Column(Integer)

--- a/dags/pipelines/garmin/tables.ddl
+++ b/dags/pipelines/garmin/tables.ddl
@@ -781,13 +781,13 @@ CREATE TABLE IF NOT EXISTS garmin.sleep (
     -- Foreign key reference.
     , user_id BIGINT NOT NULL REFERENCES garmin.user (user_id)
 
-    -- Non-nullable timestamps.
+    -- Non-nullable timestamps and calendar date.
     , start_ts TIMESTAMPTZ NOT NULL
     , end_ts TIMESTAMPTZ NOT NULL
     , timezone_offset_hours FLOAT NOT NULL
+    , calendar_date DATE NOT NULL
 
     -- Sleep session metadata.
-    , calendar_date DATE NOT NULL
     , sleep_version INTEGER
     , age_group TEXT
     , respiration_version INTEGER
@@ -909,7 +909,8 @@ COMMENT ON COLUMN garmin.sleep.timezone_offset_hours IS
 'Timezone offset from UTC in hours to infer local time '
 '(e.g., -7.0 for UTC-07:00, 5.5 for UTC+05:30).';
 COMMENT ON COLUMN garmin.sleep.calendar_date IS
-'Calendar date of the sleep session.';
+'Calendar date assigned to the sleep session by Garmin Connect. Sourced from '
+'dailySleepDTO.calendarDate. Together with user_id forms a unique constraint.';
 COMMENT ON COLUMN garmin.sleep.sleep_version IS
 'Version of sleep tracking algorithm used.';
 COMMENT ON COLUMN garmin.sleep.age_group IS
@@ -1044,6 +1045,55 @@ COMMENT ON COLUMN garmin.sleep.create_ts IS
 'Timestamp when the record was created in the database.';
 COMMENT ON COLUMN garmin.sleep.update_ts IS
 'Timestamp when the record was last modified in the database.';
+
+----------------------------------------------------------------------------------------
+
+-- Sleep stage classification intervals during sleep sessions.
+-- Time interval: Variable-length contiguous intervals (one row per stage segment).
+CREATE TABLE IF NOT EXISTS garmin.sleep_level (
+    sleep_id INTEGER REFERENCES garmin.sleep (sleep_id) ON DELETE CASCADE
+    , start_ts TIMESTAMPTZ NOT NULL
+    , end_ts TIMESTAMPTZ NOT NULL
+    , stage INTEGER NOT NULL
+    , stage_label TEXT NOT NULL
+
+    -- Audit fields.
+    , create_ts TIMESTAMPTZ NOT NULL DEFAULT NOW()
+
+    -- Primary key.
+    , PRIMARY KEY (sleep_id, start_ts)
+);
+
+-- Create indexes on sleep_level table.
+CREATE INDEX IF NOT EXISTS sleep_level_sleep_id_idx
+ON garmin.sleep_level (sleep_id);
+CREATE INDEX IF NOT EXISTS sleep_level_start_ts_brin_idx
+ON garmin.sleep_level USING brin (start_ts);
+CREATE INDEX IF NOT EXISTS sleep_level_stage_idx
+ON garmin.sleep_level (stage);
+
+-- Table comment.
+COMMENT ON TABLE garmin.sleep_level IS
+'Sleep stage classification intervals from Garmin Connect sleepLevels array. '
+'Each row is a contiguous interval during which a single discrete sleep stage '
+'(Deep, Light, REM, Awake) was detected. Used to reconstruct the per-night '
+'sleep stages timeline shown in the Garmin Connect sleep view.';
+
+-- Column comments for sleep_level table.
+COMMENT ON COLUMN garmin.sleep_level.sleep_id IS
+'References the sleep session identifier.';
+COMMENT ON COLUMN garmin.sleep_level.start_ts IS
+'Start timestamp of the sleep stage interval.';
+COMMENT ON COLUMN garmin.sleep_level.end_ts IS
+'End timestamp of the sleep stage interval.';
+COMMENT ON COLUMN garmin.sleep_level.stage IS
+'Sleep stage code: 0=Deep, 1=Light, 2=REM, 3=Awake. Sourced from '
+'sleepLevels[*].activityLevel in the Garmin SLEEP JSON response.';
+COMMENT ON COLUMN garmin.sleep_level.stage_label IS
+'Human-readable sleep stage label corresponding to stage (DEEP, LIGHT, REM, '
+'AWAKE). Denormalized for query convenience.';
+COMMENT ON COLUMN garmin.sleep_level.create_ts IS
+'Timestamp when the record was created in the database.';
 
 ----------------------------------------------------------------------------------------
 

--- a/dags/pipelines/garmin/tables.ddl
+++ b/dags/pipelines/garmin/tables.ddl
@@ -787,7 +787,7 @@ CREATE TABLE IF NOT EXISTS garmin.sleep (
     , timezone_offset_hours FLOAT NOT NULL
 
     -- Sleep session metadata.
-    , calendar_date TEXT
+    , calendar_date DATE NOT NULL
     , sleep_version INTEGER
     , age_group TEXT
     , respiration_version INTEGER
@@ -877,6 +877,8 @@ CREATE TABLE IF NOT EXISTS garmin.sleep (
 -- Create indexes on sleep table.
 CREATE UNIQUE INDEX IF NOT EXISTS sleep_user_id_start_ts_unique_idx
 ON garmin.sleep (user_id, start_ts);
+CREATE UNIQUE INDEX IF NOT EXISTS sleep_user_id_calendar_date_unique_idx
+ON garmin.sleep (user_id, calendar_date);
 CREATE INDEX IF NOT EXISTS sleep_start_ts_brin_idx
 ON garmin.sleep USING brin (start_ts);
 CREATE INDEX IF NOT EXISTS sleep_end_ts_brin_idx

--- a/dags/pipelines/garmin/utility_scripts/backfill_sleep_level.py
+++ b/dags/pipelines/garmin/utility_scripts/backfill_sleep_level.py
@@ -29,7 +29,7 @@ import re
 import traceback
 from datetime import date, datetime, timezone
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional, Tuple
 
 from sqlalchemy.orm import Session
 
@@ -42,7 +42,9 @@ from dags.pipelines.garmin.sqla_models import Sleep, SleepLevel
 SLEEP_FILENAME_RE = re.compile(r"^(?P<user_id>\d+)_SLEEP_.*\.json$")
 
 
-def _parse_sleep_file(file_path: Path) -> Optional[tuple]:
+def _parse_sleep_file(
+    file_path: Path,
+) -> Optional[Tuple[int, date, list[dict[str, Any]]]]:
     """
     Parse a SLEEP JSON file and extract the calendar date and sleep levels.
 
@@ -114,8 +116,10 @@ def backfill_sleep_level(store_dir: Path) -> None:
     Walk store_dir for SLEEP JSON files and backfill garmin.sleep_level.
 
     For each file: parse calendar_date, look up the existing sleep row by
-    (user_id, calendar_date), delete any existing sleep_level rows for that sleep_id,
-    and insert fresh rows from the file's sleepLevels array.
+    (user_id, calendar_date), and insert sleep_level rows from the file's
+    sleepLevels array using INSERT ... ON CONFLICT DO NOTHING. Existing rows for
+    the same (sleep_id, start_ts) are left in place, so the script can be re-run
+    safely without deleting prior data.
 
     :param store_dir: Garmin store directory containing SLEEP JSON files.
     """

--- a/dags/pipelines/garmin/utility_scripts/backfill_sleep_level.py
+++ b/dags/pipelines/garmin/utility_scripts/backfill_sleep_level.py
@@ -67,16 +67,7 @@ def _parse_sleep_file(
     if not calendar_date_str:
         LOGGER.warning(f"⚠️ Skipping {file_path.name}: no dailySleepDTO.calendarDate.")
         return None
-    try:
-        calendar_date = date.fromisoformat(calendar_date_str)
-    except ValueError:
-        # Treat malformed dates as a skip rather than a hard failure so one bad
-        # file does not poison the entire backfill run stats.
-        LOGGER.warning(
-            f"⚠️ Skipping {file_path.name}: invalid dailySleepDTO.calendarDate "
-            f"{calendar_date_str!r}."
-        )
-        return None
+    calendar_date = date.fromisoformat(calendar_date_str)
 
     sleep_levels = sleep_data.get("sleepLevels") or []
     return user_id, calendar_date, sleep_levels
@@ -100,12 +91,10 @@ def _build_sleep_level_records(sleep_id: int, sleep_levels: list) -> list:
             continue
         try:
             stage = SleepStage(int(activity_level))
-        except (ValueError, TypeError):
-            # ValueError: unknown int code. TypeError: activity_level is not
-            # numeric/string (malformed JSON). Both treated as skip.
+        except ValueError:
             LOGGER.warning(
-                f"⚠️ Unparseable sleep stage value {activity_level!r} for "
-                f"sleep_id={sleep_id}; skipping interval."
+                f"⚠️ Unknown sleep stage code {activity_level} for sleep_id="
+                f"{sleep_id}; skipping interval."
             )
             continue
         records.append(

--- a/dags/pipelines/garmin/utility_scripts/backfill_sleep_level.py
+++ b/dags/pipelines/garmin/utility_scripts/backfill_sleep_level.py
@@ -132,7 +132,9 @@ def backfill_sleep_level(store_dir: Path) -> None:
     success = 0
     skipped = 0
     failed = 0
-    inserted_rows = 0
+    # Counts rows submitted to INSERT, not rows actually written: ON CONFLICT DO
+    # NOTHING means existing (sleep_id, start_ts) rows are silently kept.
+    processed_rows = 0
 
     with Session(engine) as session:
         for sleep_file in sleep_files:
@@ -179,7 +181,7 @@ def backfill_sleep_level(store_dir: Path) -> None:
                     on_conflict_update=False,
                 )
                 session.commit()
-                inserted_rows += len(records)
+                processed_rows += len(records)
                 success += 1
                 LOGGER.info(
                     f"✅ {sleep_file.name}: processed {len(records)} levels for "
@@ -192,8 +194,8 @@ def backfill_sleep_level(store_dir: Path) -> None:
 
     LOGGER.info(
         f"\n🎯 Backfill complete: {success} files processed, "
-        f"{skipped} skipped, {failed} failed, {inserted_rows} sleep_level rows "
-        f"inserted."
+        f"{skipped} skipped, {failed} failed, {processed_rows} sleep_level rows "
+        f"processed (existing rows kept via ON CONFLICT DO NOTHING)."
     )
 
 

--- a/dags/pipelines/garmin/utility_scripts/backfill_sleep_level.py
+++ b/dags/pipelines/garmin/utility_scripts/backfill_sleep_level.py
@@ -1,0 +1,218 @@
+"""
+Backfill garmin.sleep_level from existing SLEEP JSON files.
+
+This utility script populates the new garmin.sleep_level table from historical SLEEP
+JSON files that were ingested before the sleep_level feature was added.
+
+It walks the Garmin store directory for SLEEP JSON files, looks up the existing
+sleep_id by (user_id, calendar_date), and inserts sleepLevels rows directly. The
+existing GarminProcessor pipeline is intentionally NOT used so the backfill does not
+re-touch the other sleep child tables (sleep_movement, spo2, hrv, etc.) or the main
+sleep row.
+
+PREREQUISITES:
+- The schema migration tighten_sleep_calendar_date.sql must already be applied so
+  (user_id, calendar_date) is unique in garmin.sleep.
+- The garmin.sleep_level table must already exist (created by tables.ddl).
+- SQL_CREDENTIALS_DIR must be set so airflow_garmin credentials can be loaded.
+
+USAGE:
+    python backfill_sleep_level.py --store-dir /path/to/garmin/store
+
+Idempotent: uses INSERT ... ON CONFLICT DO NOTHING on (sleep_id, start_ts), matching
+the runtime processor pattern, so the script can be re-run safely.
+"""
+
+import argparse
+import json
+import re
+import traceback
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from dags.lib.logging_utils import LOGGER
+from dags.lib.sql_utils import get_lens_engine, upsert_model_instances
+from dags.pipelines.garmin.constants import SleepStage
+from dags.pipelines.garmin.sqla_models import Sleep, SleepLevel
+
+# Filename pattern: <user_id>_SLEEP_<timestamp>.json.
+SLEEP_FILENAME_RE = re.compile(r"^(?P<user_id>\d+)_SLEEP_.*\.json$")
+
+
+def _parse_sleep_file(file_path: Path) -> Optional[tuple]:
+    """
+    Parse a SLEEP JSON file and extract the calendar date and sleep levels.
+
+    :param file_path: Path to the SLEEP JSON file.
+    :return: Tuple of (user_id, calendar_date, sleep_levels) if parseable, otherwise
+        None.
+    """
+
+    match = SLEEP_FILENAME_RE.match(file_path.name)
+    if not match:
+        LOGGER.warning(f"⚠️ Skipping {file_path.name}: invalid filename pattern.")
+        return None
+    user_id = int(match.group("user_id"))
+
+    with open(file_path, "r", encoding="utf-8") as f:
+        sleep_data = json.load(f)
+
+    daily_sleep_dto = sleep_data.get("dailySleepDTO") or {}
+    calendar_date_str = daily_sleep_dto.get("calendarDate")
+    if not calendar_date_str:
+        LOGGER.warning(f"⚠️ Skipping {file_path.name}: no dailySleepDTO.calendarDate.")
+        return None
+    calendar_date = date.fromisoformat(calendar_date_str)
+
+    sleep_levels = sleep_data.get("sleepLevels") or []
+    return user_id, calendar_date, sleep_levels
+
+
+def _build_sleep_level_records(sleep_id: int, sleep_levels: list) -> list:
+    """
+    Convert raw sleepLevels JSON entries to SleepLevel ORM instances.
+
+    :param sleep_id: Sleep session identifier.
+    :param sleep_levels: Raw sleepLevels list from the JSON file.
+    :return: List of SleepLevel instances ready to be persisted.
+    """
+
+    records = []
+    for level in sleep_levels:
+        start_gmt_str = level.get("startGMT")
+        end_gmt_str = level.get("endGMT")
+        activity_level = level.get("activityLevel")
+        if start_gmt_str is None or end_gmt_str is None or activity_level is None:
+            continue
+        try:
+            stage = SleepStage(int(activity_level))
+        except ValueError:
+            LOGGER.warning(
+                f"⚠️ Unknown sleep stage code {activity_level} for sleep_id="
+                f"{sleep_id}; skipping interval."
+            )
+            continue
+        records.append(
+            SleepLevel(
+                sleep_id=sleep_id,
+                start_ts=datetime.fromisoformat(start_gmt_str).replace(
+                    tzinfo=timezone.utc
+                ),
+                end_ts=datetime.fromisoformat(end_gmt_str).replace(tzinfo=timezone.utc),
+                stage=stage.value,
+                stage_label=stage.name,
+            )
+        )
+    return records
+
+
+def backfill_sleep_level(store_dir: Path) -> None:
+    """
+    Walk store_dir for SLEEP JSON files and backfill garmin.sleep_level.
+
+    For each file: parse calendar_date, look up the existing sleep row by
+    (user_id, calendar_date), delete any existing sleep_level rows for that sleep_id,
+    and insert fresh rows from the file's sleepLevels array.
+
+    :param store_dir: Garmin store directory containing SLEEP JSON files.
+    """
+
+    sleep_files = sorted(store_dir.rglob("*_SLEEP_*.json"))
+    LOGGER.info(f"🔍 Found {len(sleep_files)} SLEEP files under {store_dir}.")
+
+    engine = get_lens_engine("airflow_garmin")
+
+    success = 0
+    skipped = 0
+    failed = 0
+    inserted_rows = 0
+
+    with Session(engine) as session:
+        for sleep_file in sleep_files:
+            try:
+                parsed = _parse_sleep_file(sleep_file)
+                if parsed is None:
+                    skipped += 1
+                    continue
+                user_id, calendar_date, sleep_levels = parsed
+
+                if not sleep_levels:
+                    LOGGER.info(
+                        f"⏭ Skipping {sleep_file.name}: no sleepLevels in file."
+                    )
+                    skipped += 1
+                    continue
+
+                sleep = (
+                    session.query(Sleep)
+                    .filter_by(user_id=user_id, calendar_date=calendar_date)
+                    .one_or_none()
+                )
+                if sleep is None:
+                    LOGGER.warning(
+                        f"⚠️ Skipping {sleep_file.name}: no garmin.sleep row for "
+                        f"user_id={user_id}, calendar_date={calendar_date}."
+                    )
+                    skipped += 1
+                    continue
+                sleep_id = sleep.sleep_id
+
+                records = _build_sleep_level_records(sleep_id, sleep_levels)
+                if not records:
+                    skipped += 1
+                    LOGGER.warning(f"⚠️ {sleep_file.name}: no valid sleepLevels rows.")
+                    continue
+
+                # Use INSERT ... ON CONFLICT DO NOTHING to match the runtime
+                # processor pattern. Idempotent on (sleep_id, start_ts).
+                upsert_model_instances(
+                    session=session,
+                    model_instances=records,
+                    conflict_columns=["sleep_id", "start_ts"],
+                    on_conflict_update=False,
+                )
+                session.commit()
+                inserted_rows += len(records)
+                success += 1
+                LOGGER.info(
+                    f"✅ {sleep_file.name}: processed {len(records)} levels for "
+                    f"sleep_id={sleep_id}."
+                )
+            except Exception:
+                session.rollback()
+                LOGGER.error(f"❌ Failed {sleep_file.name}:\n{traceback.format_exc()}")
+                failed += 1
+
+    LOGGER.info(
+        f"\n🎯 Backfill complete: {success} files processed, "
+        f"{skipped} skipped, {failed} failed, {inserted_rows} sleep_level rows "
+        f"inserted."
+    )
+
+
+def main() -> None:
+    """
+    Parse CLI arguments and run the sleep_level backfill.
+    """
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--store-dir",
+        required=True,
+        type=Path,
+        help="Garmin store directory containing SLEEP JSON files (e.g. "
+        "/home/user/airflow/data/garmin/store).",
+    )
+    args = parser.parse_args()
+
+    if not args.store_dir.exists():
+        raise SystemExit(f"❌ Store directory does not exist: {args.store_dir}.")
+
+    backfill_sleep_level(args.store_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/dags/pipelines/garmin/utility_scripts/backfill_sleep_level.py
+++ b/dags/pipelines/garmin/utility_scripts/backfill_sleep_level.py
@@ -67,7 +67,16 @@ def _parse_sleep_file(
     if not calendar_date_str:
         LOGGER.warning(f"⚠️ Skipping {file_path.name}: no dailySleepDTO.calendarDate.")
         return None
-    calendar_date = date.fromisoformat(calendar_date_str)
+    try:
+        calendar_date = date.fromisoformat(calendar_date_str)
+    except ValueError:
+        # Treat malformed dates as a skip rather than a hard failure so one bad
+        # file does not poison the entire backfill run stats.
+        LOGGER.warning(
+            f"⚠️ Skipping {file_path.name}: invalid dailySleepDTO.calendarDate "
+            f"{calendar_date_str!r}."
+        )
+        return None
 
     sleep_levels = sleep_data.get("sleepLevels") or []
     return user_id, calendar_date, sleep_levels
@@ -91,10 +100,12 @@ def _build_sleep_level_records(sleep_id: int, sleep_levels: list) -> list:
             continue
         try:
             stage = SleepStage(int(activity_level))
-        except ValueError:
+        except (ValueError, TypeError):
+            # ValueError: unknown int code. TypeError: activity_level is not
+            # numeric/string (malformed JSON). Both treated as skip.
             LOGGER.warning(
-                f"⚠️ Unknown sleep stage code {activity_level} for sleep_id="
-                f"{sleep_id}; skipping interval."
+                f"⚠️ Unparseable sleep stage value {activity_level!r} for "
+                f"sleep_id={sleep_id}; skipping interval."
             )
             continue
         records.append(

--- a/dags/pipelines/garmin/utility_scripts/tighten_sleep_calendar_date.sql
+++ b/dags/pipelines/garmin/utility_scripts/tighten_sleep_calendar_date.sql
@@ -1,0 +1,37 @@
+-- ----------------------------------------------------------------------------------------
+-- Tighten garmin.sleep.calendar_date schema.
+--
+-- Converts calendar_date from TEXT to DATE, makes it NOT NULL, and adds a unique
+-- index on (user_id, calendar_date) so each user's calendar date maps to exactly one
+-- sleep session. Required prerequisite for the sleep_level table backfill.
+--
+-- Safety: empirically verified on production (5051 rows): zero NULLs, every value
+-- parses as DATE, and (user_id, calendar_date) is already unique. Run this once
+-- before deploying the sleep_level feature.
+--
+-- Usage:
+--   psql -h <host> -U postgres -d lens -f tighten_sleep_calendar_date.sql
+-- ----------------------------------------------------------------------------------------
+
+BEGIN;
+
+-- Convert TEXT to DATE in place. Fails fast if any row contains a non-parseable
+-- value, which is the desired behavior since we are tightening the contract.
+ALTER TABLE garmin.sleep
+ALTER COLUMN calendar_date TYPE DATE
+USING calendar_date::DATE;
+
+-- Enforce non-null. Fails fast if any row has a NULL calendar_date.
+ALTER TABLE garmin.sleep
+ALTER COLUMN calendar_date SET NOT NULL;
+
+-- Add unique index alongside the existing (user_id, start_ts) unique index.
+CREATE UNIQUE INDEX IF NOT EXISTS sleep_user_id_calendar_date_unique_idx
+ON garmin.sleep (user_id, calendar_date);
+
+-- Refresh the column comment to reflect the new contract.
+COMMENT ON COLUMN garmin.sleep.calendar_date IS
+'Calendar date assigned to the sleep session by Garmin Connect. Sourced from '
+'dailySleepDTO.calendarDate. Together with user_id forms a unique constraint.';
+
+COMMIT;

--- a/tests/dags/pipelines/garmin/test_process.py
+++ b/tests/dags/pipelines/garmin/test_process.py
@@ -624,18 +624,16 @@ class TestGarminProcessor:
         self, mock_upsert, processor, mock_session
     ):
         """
-        Test _process_sleep_level when every interval is unparseable.
+        Test _process_sleep_level when every interval has an unknown stage code.
 
-        Covers both unknown int stage codes (ValueError) and non-numeric activityLevel
-        values like dicts (TypeError). Should log and return without calling upsert (no
-        spurious empty insert).
+        Should log and return without calling upsert (no spurious empty insert).
 
         :param mock_upsert: Mock upsert function.
         :param processor: GarminProcessor fixture.
         :param mock_session: Mock session fixture.
         """
 
-        # Arrange: payload with one unknown int code and one non-numeric value.
+        # Arrange: payload with only unknown stage codes.
         data = {
             "sleepLevels": [
                 {
@@ -646,7 +644,7 @@ class TestGarminProcessor:
                 {
                     "startGMT": "2022-01-01T01:00:00.0",
                     "endGMT": "2022-01-01T02:00:00.0",
-                    "activityLevel": {"unexpected": "object"},
+                    "activityLevel": 100,
                 },
             ]
         }

--- a/tests/dags/pipelines/garmin/test_process.py
+++ b/tests/dags/pipelines/garmin/test_process.py
@@ -624,16 +624,18 @@ class TestGarminProcessor:
         self, mock_upsert, processor, mock_session
     ):
         """
-        Test _process_sleep_level when every interval has an unknown stage code.
+        Test _process_sleep_level when every interval is unparseable.
 
-        Should log and return without calling upsert (no spurious empty insert).
+        Covers both unknown int stage codes (ValueError) and non-numeric activityLevel
+        values like dicts (TypeError). Should log and return without calling upsert (no
+        spurious empty insert).
 
         :param mock_upsert: Mock upsert function.
         :param processor: GarminProcessor fixture.
         :param mock_session: Mock session fixture.
         """
 
-        # Arrange: payload with only unknown stage codes.
+        # Arrange: payload with one unknown int code and one non-numeric value.
         data = {
             "sleepLevels": [
                 {
@@ -644,7 +646,7 @@ class TestGarminProcessor:
                 {
                     "startGMT": "2022-01-01T01:00:00.0",
                     "endGMT": "2022-01-01T02:00:00.0",
-                    "activityLevel": 100,
+                    "activityLevel": {"unexpected": "object"},
                 },
             ]
         }

--- a/tests/dags/pipelines/garmin/test_process.py
+++ b/tests/dags/pipelines/garmin/test_process.py
@@ -455,6 +455,34 @@ class TestGarminProcessor:
         # Now the function should return the sleep_id from the persisted instance.
         assert result == 123456789
 
+    def test_process_sleep_base_missing_calendar_date(self, processor, mock_session):
+        """
+        Test _process_sleep_base raises ValueError when calendarDate is missing.
+
+        Garmin's calendarDate is the source of truth for the sleep session day and is
+        used by the unique (user_id, calendar_date) constraint. Missing values must fail
+        loudly rather than silently insert a NULL.
+
+        :param processor: GarminProcessor fixture.
+        :param mock_session: Mock session fixture.
+        """
+
+        # Arrange.
+        sleep_data = {
+            "dailySleepDTO": {
+                "sleepStartTimestampGMT": 1641078000000,
+                "sleepEndTimestampGMT": 1641106800000,
+                "sleepStartTimestampLocal": 1641052800000,
+                "sleepTimeSeconds": 28800,
+                # Intentionally no calendarDate.
+            }
+        }
+        processor.user_id = 1
+
+        # Act & Assert.
+        with pytest.raises(ValueError, match="missing dailySleepDTO.calendarDate"):
+            processor._process_sleep_base(sleep_data, mock_session)
+
     @patch("dags.pipelines.garmin.process.upsert_model_instances")
     def test_process_sleep_movement(self, mock_upsert, processor, mock_session):
         """

--- a/tests/dags/pipelines/garmin/test_process.py
+++ b/tests/dags/pipelines/garmin/test_process.py
@@ -38,6 +38,7 @@ from dags.pipelines.garmin.sqla_models import (
     RacePredictions,
     Respiration,
     Sleep,
+    SleepLevel,
     SleepMovement,
     SleepRestlessMoment,
     SpO2,
@@ -150,6 +151,28 @@ class TestGarminProcessor:
             "wellnessSpO2SleepSummaryDTO": {
                 "numberOfEventsBelowThreshold": 2,
             },
+            "sleepLevels": [
+                {
+                    "startGMT": "2022-01-01T00:00:00.0",
+                    "endGMT": "2022-01-01T01:00:00.0",
+                    "activityLevel": 1,  # LIGHT
+                },
+                {
+                    "startGMT": "2022-01-01T01:00:00.0",
+                    "endGMT": "2022-01-01T02:30:00.0",
+                    "activityLevel": 0,  # DEEP
+                },
+                {
+                    "startGMT": "2022-01-01T02:30:00.0",
+                    "endGMT": "2022-01-01T03:00:00.0",
+                    "activityLevel": 2,  # REM
+                },
+                {
+                    "startGMT": "2022-01-01T03:00:00.0",
+                    "endGMT": "2022-01-01T03:15:00.0",
+                    "activityLevel": 3,  # AWAKE
+                },
+            ],
             "sleepMovement": [
                 {"startGMT": "2022-01-01T00:30:00Z", "activityLevel": 0.1},
                 {"startGMT": "2022-01-01T01:00:00Z", "activityLevel": 0.2},
@@ -392,10 +415,9 @@ class TestGarminProcessor:
         processor._process_sleep(sleep_file, mock_session)
 
         # Assert.
-        # Verify upsert was called for sleep base record + timeseries data.
-        assert (
-            mock_upsert.call_count == 6
-        )  # Sleep base + Movement, restless, SpO2, HRV, breathing
+        # Verify upsert was called for sleep base record + timeseries data
+        # (sleep_level + movement + restless + SpO2 + HRV + breathing).
+        assert mock_upsert.call_count == 7
 
         # Check first call is for sleep base record.
         first_call = mock_upsert.call_args_list[0]
@@ -404,6 +426,21 @@ class TestGarminProcessor:
         assert len(first_call[1]["model_instances"]) == 1
         assert isinstance(first_call[1]["model_instances"][0], Sleep)
         assert first_call[1]["model_instances"][0].user_id == 1
+
+        # Verify one of the calls handled the four SleepLevel rows.
+        sleep_level_calls = [
+            call
+            for call in mock_upsert.call_args_list
+            if all(isinstance(m, SleepLevel) for m in call.kwargs["model_instances"])
+            and call.kwargs["model_instances"]
+        ]
+        assert len(sleep_level_calls) == 1
+        assert len(sleep_level_calls[0].kwargs["model_instances"]) == 4
+        assert sleep_level_calls[0].kwargs["conflict_columns"] == [
+            "sleep_id",
+            "start_ts",
+        ]
+        assert sleep_level_calls[0].kwargs["on_conflict_update"] is False
 
     @patch("dags.pipelines.garmin.process.upsert_model_instances")
     def test_process_sleep_base(self, mock_upsert, processor, mock_session):
@@ -459,29 +496,164 @@ class TestGarminProcessor:
         """
         Test _process_sleep_base raises ValueError when calendarDate is missing.
 
-        Garmin's calendarDate is the source of truth for the sleep session day and is
-        used by the unique (user_id, calendar_date) constraint. Missing values must fail
-        loudly rather than silently insert a NULL.
+        Garmin's calendarDate is the source of truth for the (user_id, calendar_date)
+        unique constraint, so a missing value must fail loudly rather than silently drop
+        the row.
 
         :param processor: GarminProcessor fixture.
         :param mock_session: Mock session fixture.
         """
 
-        # Arrange.
+        # Arrange: dailySleepDTO without calendarDate.
         sleep_data = {
             "dailySleepDTO": {
                 "sleepStartTimestampGMT": 1641078000000,
                 "sleepEndTimestampGMT": 1641106800000,
                 "sleepStartTimestampLocal": 1641052800000,
                 "sleepTimeSeconds": 28800,
-                # Intentionally no calendarDate.
             }
         }
-        processor.user_id = 1
 
         # Act & Assert.
-        with pytest.raises(ValueError, match="missing dailySleepDTO.calendarDate"):
+        processor.user_id = 1
+        with pytest.raises(ValueError, match="calendarDate"):
             processor._process_sleep_base(sleep_data, mock_session)
+
+    @patch("dags.pipelines.garmin.process.upsert_model_instances")
+    def test_process_sleep_level(self, mock_upsert, processor, mock_session):
+        """
+        Test _process_sleep_level method.
+
+        Verifies that sleepLevels intervals are converted to SleepLevel ORM instances
+        with the correct UTC timestamps and stage labels, that the upsert is called with
+        insert-or-ignore semantics on (sleep_id, start_ts), and that intervals with
+        unknown stage codes are skipped.
+
+        :param mock_upsert: Mock upsert function.
+        :param processor: GarminProcessor fixture.
+        :param mock_session: Mock session fixture.
+        """
+
+        # Arrange.
+        data = {
+            "sleepLevels": [
+                {
+                    "startGMT": "2022-01-01T00:00:00.0",
+                    "endGMT": "2022-01-01T01:00:00.0",
+                    "activityLevel": 1,  # LIGHT
+                },
+                {
+                    "startGMT": "2022-01-01T01:00:00.0",
+                    "endGMT": "2022-01-01T01:30:00.0",
+                    "activityLevel": 0,  # DEEP
+                },
+                {
+                    "startGMT": "2022-01-01T01:30:00.0",
+                    "endGMT": "2022-01-01T02:00:00.0",
+                    "activityLevel": 2,  # REM
+                },
+                {
+                    "startGMT": "2022-01-01T02:00:00.0",
+                    "endGMT": "2022-01-01T02:15:00.0",
+                    "activityLevel": 3,  # AWAKE
+                },
+                {
+                    # Unknown code: should be skipped without raising.
+                    "startGMT": "2022-01-01T02:15:00.0",
+                    "endGMT": "2022-01-01T02:30:00.0",
+                    "activityLevel": 99,
+                },
+            ]
+        }
+
+        # Act.
+        processor.user_id = 123456789
+        processor._process_sleep_level(data, 123456, mock_session)
+
+        # Assert: upsert called once with insert-or-ignore semantics.
+        mock_upsert.assert_called_once()
+        kwargs = mock_upsert.call_args.kwargs
+        assert kwargs["session"] == mock_session
+        assert kwargs["conflict_columns"] == ["sleep_id", "start_ts"]
+        assert kwargs["on_conflict_update"] is False
+
+        # Four valid intervals (the unknown code was dropped).
+        records = kwargs["model_instances"]
+        assert len(records) == 4
+        assert all(isinstance(rec, SleepLevel) for rec in records)
+
+        # Verify field mapping for the first record (LIGHT).
+        first = records[0]
+        assert first.sleep_id == 123456
+        assert first.start_ts == datetime(2022, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+        assert first.end_ts == datetime(2022, 1, 1, 1, 0, 0, tzinfo=timezone.utc)
+        assert first.stage == 1
+        assert first.stage_label == "LIGHT"
+
+        # Verify all stage labels in order.
+        assert [rec.stage_label for rec in records] == [
+            "LIGHT",
+            "DEEP",
+            "REM",
+            "AWAKE",
+        ]
+
+    @patch("dags.pipelines.garmin.process.upsert_model_instances")
+    def test_process_sleep_level_empty(self, mock_upsert, processor, mock_session):
+        """
+        Test _process_sleep_level with no sleepLevels in payload.
+
+        Should return early without calling upsert.
+
+        :param mock_upsert: Mock upsert function.
+        :param processor: GarminProcessor fixture.
+        :param mock_session: Mock session fixture.
+        """
+
+        # Arrange: payload with no sleepLevels key.
+        data = {}
+
+        # Act.
+        processor._process_sleep_level(data, 123456, mock_session)
+
+        # Assert.
+        mock_upsert.assert_not_called()
+
+    @patch("dags.pipelines.garmin.process.upsert_model_instances")
+    def test_process_sleep_level_all_invalid(
+        self, mock_upsert, processor, mock_session
+    ):
+        """
+        Test _process_sleep_level when every interval has an unknown stage code.
+
+        Should log and return without calling upsert (no spurious empty insert).
+
+        :param mock_upsert: Mock upsert function.
+        :param processor: GarminProcessor fixture.
+        :param mock_session: Mock session fixture.
+        """
+
+        # Arrange: payload with only unknown stage codes.
+        data = {
+            "sleepLevels": [
+                {
+                    "startGMT": "2022-01-01T00:00:00.0",
+                    "endGMT": "2022-01-01T01:00:00.0",
+                    "activityLevel": 99,
+                },
+                {
+                    "startGMT": "2022-01-01T01:00:00.0",
+                    "endGMT": "2022-01-01T02:00:00.0",
+                    "activityLevel": 100,
+                },
+            ]
+        }
+
+        # Act.
+        processor._process_sleep_level(data, 123456, mock_session)
+
+        # Assert.
+        mock_upsert.assert_not_called()
 
     @patch("dags.pipelines.garmin.process.upsert_model_instances")
     def test_process_sleep_movement(self, mock_upsert, processor, mock_session):


### PR DESCRIPTION
Closes #124

## Summary

Adds per-interval sleep stage classification to the Garmin pipeline so dashboards can render the Garmin Connect "sleep stages tonight" timeline (Deep / Light / REM / Awake). Bundles a small schema prerequisite that the new feature depends on.

Two commits:

1. **`feat(garmin): tighten sleep.calendar_date schema`**
   - Convert `garmin.sleep.calendar_date` from nullable `TEXT` to `DATE NOT NULL`.
   - Add unique index on `(user_id, calendar_date)`.
   - Processor extracts `dailySleepDTO.calendarDate` explicitly and raises `ValueError` if missing.
   - Verified empirically on production (5051 rows): zero NULLs, every value parses as DATE, `(user_id, calendar_date)` is already unique.
   - Includes one-shot migration script `utility_scripts/tighten_sleep_calendar_date.sql`.

2. **`feat(garmin): add sleep_level table from sleepLevels`**
   - New `garmin.sleep_level` table with `(sleep_id, start_ts)` PK, `end_ts`, `stage` (int code), and `stage_label` (readable name).
   - New `SleepStage` `IntEnum` mapping Garmin's `activityLevel` codes (0-3) to labels (Deep/Light/REM/Awake).
   - New `SleepLevel` ORM model and `_process_sleep_level` processor method.
   - Inserts use `INSERT ... ON CONFLICT DO NOTHING` on `(sleep_id, start_ts)`, matching the idempotency pattern of sibling sleep timeseries tables (sleep_movement, spo2, hrv).
   - Includes backfill script `utility_scripts/backfill_sleep_level.py` that walks the existing Garmin store directory and populates `sleep_level` for historical sessions without re-touching other sleep child tables. Relies on the unique `(user_id, calendar_date)` constraint added in commit 1 to look up the parent `sleep_id`.

## Why bundle the schema change

The backfill needs a stable lookup key from a SLEEP JSON file to its existing `garmin.sleep` row. Filename timestamps are bedtime (sometimes day N-1) while `dailySleepDTO.calendarDate` is the assigned session day, so `calendar_date` is the only reliable join key. Splitting the two would either leave the backfill broken between merges or require a temporary lookup hack.

## Test plan

- [x] All existing tests pass (252 passed, 2 skipped)
- [x] New test `test_process_sleep_base_missing_calendar_date` verifies the `ValueError` raise path
- [x] New tests `test_process_sleep_level`, `test_process_sleep_level_empty`, `test_process_sleep_level_all_invalid` cover the new processor method (valid intervals, empty array, all-unknown-codes case)
- [x] `test_process_sleep_file` updated to verify the new sleep_level upsert call uses `conflict_columns=["sleep_id", "start_ts"]` and `on_conflict_update=False`
- [x] Schema migration applied locally and verified (159 rows migrated cleanly, sleep_level table created)
- [x] `make check-format` clean (one pre-existing unrelated black warning on `tests/dags/lib/test_sql_utils.py` not introduced by this PR)
- [ ] After merge: apply `tighten_sleep_calendar_date.sql` to diegotower production DB
- [ ] After merge: run `backfill_sleep_level.py` on diegotower against the existing Garmin store