### PR TITLE
fix(db): remove unsupported IF NOT EXISTS from CREATE DATABASE

### DIFF
--- a/dags/database.ddl
+++ b/dags/database.ddl
@@ -16,8 +16,9 @@ Connection:
     psql -h localhost -U postgres -d postgres -f dags/database.ddl
 
 Notes:
-  - Uses IF NOT EXISTS for idempotent execution (safe to run multiple times).
   - Character encoding and collation are set for UTF-8 support.
+  - Re-running this script will fail if the database already exists; drop it
+    first or skip this step.
 ========================================================================================
 */
 
@@ -29,16 +30,12 @@ SET standard_conforming_strings = on;
 -- DATABASE CREATION
 ----------------------------------------------------------------------------------------
 
--- Note: IF NOT EXISTS requires PostgreSQL 9.5+
--- SQLFluff linter doesn't support this syntax, but PostgreSQL does.
--- noqa: disable=CP02
-CREATE DATABASE IF NOT EXISTS lens
+CREATE DATABASE lens
     WITH
     ENCODING = 'UTF8'
     LC_COLLATE = 'en_US.UTF-8'
     LC_CTYPE = 'en_US.UTF-8'
     TEMPLATE = template0;
--- noqa: enable=CP02
 
 COMMENT ON DATABASE lens IS
     'Data pipeline analytics database.';


### PR DESCRIPTION
## Summary

PostgreSQL does not support `CREATE DATABASE IF NOT EXISTS` at any version. The script's comment claiming support "in PostgreSQL 9.5+" is incorrect, and the `noqa: disable=CP02` markers only suppressed the SQLFluff warning rather than fixing the syntax error that would occur at runtime.

### Changes

- Drop `IF NOT EXISTS` from the `CREATE DATABASE` statement.
- Remove the 3 explanatory comment lines and the 2 noqa markers around the statement (no longer needed).
- Replace the misleading "Uses IF NOT EXISTS for idempotent execution" bullet in the header with an accurate note that re-running against an existing database will fail.

## Test plan

- [ ] `psql -U postgres -d postgres -f dags/database.ddl` succeeds on a clean cluster.
- [ ] Re-running the same command produces the expected `database "lens" already exists` error (confirms the prior version never actually worked).
- [ ] `make check-format` still passes (file is in `.sqlfluffignore`, so no change expected).