### PR TITLE
fix(sql): remove invalid IF NOT EXISTS from CREATE ROLE/USER

### DIFF
--- a/dags/iam.sql
+++ b/dags/iam.sql
@@ -10,9 +10,11 @@ Description:  This script creates users, roles, and permissions associated with
 Prerequisites:
   - The lens database must exist (created by database.ddl).
   - Schemas must be created (created by schemas.ddl).
-  - Must have superuser privileges (typically postgres user)..
+  - Must have superuser privileges (typically postgres user).
   - IMPORTANT: Replace all <REDACTED> password placeholders with actual passwords
-    before running this script
+    before running this script.
+  - Re-running this script will fail if roles or users already exist; drop
+    them first or skip this step.
 
 Optional Components:
   - Superset roles and permissions (see SUPERSET ROLES AND PERMISSIONS section).
@@ -39,20 +41,20 @@ Connection:
 SET client_encoding = 'UTF8';
 
 -- Read-only access role for data consumers.
-CREATE ROLE IF NOT EXISTS readers;
+CREATE ROLE readers;
 
 ----------------------------------------------------------------------------------------
 -- AIRFLOW SERVICE USERS
 ----------------------------------------------------------------------------------------
 
 -- Airflow service user for Garmin data pipeline operations.
-CREATE USER IF NOT EXISTS airflow_garmin
+CREATE USER airflow_garmin
     WITH PASSWORD '<REDACTED>';
 COMMENT ON ROLE airflow_garmin IS
     'Service user for Airflow Garmin data pipeline operations.';
 
 -- Airflow service user for LinkedIn data pipeline operations.
-CREATE USER IF NOT EXISTS airflow_linkedin
+CREATE USER airflow_linkedin
     WITH PASSWORD '<REDACTED>';
 COMMENT ON ROLE airflow_linkedin IS
     'Service user for Airflow LinkedIn data pipeline operations.';
@@ -67,7 +69,7 @@ GRANT readers TO airflow_linkedin;
 ----------------------------------------------------------------------------------------
 
 -- Create specialized role for infrastructure monitoring operations.
-CREATE ROLE IF NOT EXISTS infra_monitor_role;
+CREATE ROLE infra_monitor_role;
 COMMENT ON ROLE infra_monitor_role IS
     'Role for infrastructure monitoring data operations including metrics ingestion '
     'and alerting.';
@@ -173,11 +175,11 @@ ALTER DEFAULT PRIVILEGES IN SCHEMA linkedin
 ----------------------------------------------------------------------------------------
 
 -- Create user for Superset service
-CREATE USER IF NOT EXISTS superset_user WITH PASSWORD '<REDACTED>';
+CREATE USER superset_user WITH PASSWORD '<REDACTED>';
 GRANT readers TO superset_user;
 
 -- Create role for Superset data upload operations.
-CREATE ROLE IF NOT EXISTS superset_upload_role;
+CREATE ROLE superset_upload_role;
 COMMENT ON ROLE superset_upload_role IS
     'Role for Apache Superset users to upload and manage ad-hoc datasets.';
 

--- a/iac/airflow/airflow_db.ddl
+++ b/iac/airflow/airflow_db.ddl
@@ -39,14 +39,14 @@ REVOKE ALL ON FUNCTION pg_cancel_backend FROM public;
 REVOKE ALL ON FUNCTION pg_terminate_backend FROM public;
 
 -- Create read-only role for analytics.
-CREATE ROLE IF NOT EXISTS readers;
+CREATE ROLE readers;
 
 ----------------------------------------------------------------------------------------
 -- AIRFLOW METADATA DATABASE AND USER
 ----------------------------------------------------------------------------------------
 
 CREATE DATABASE airflow_db;
-CREATE USER IF NOT EXISTS airflow WITH PASSWORD '<REDACTED>';
+CREATE USER airflow WITH PASSWORD '<REDACTED>';
 GRANT ALL PRIVILEGES ON DATABASE airflow_db TO airflow;
 
 ----------------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Remove `IF NOT EXISTS` from `CREATE ROLE` and `CREATE USER` statements in `dags/iam.sql` (6 occurrences) and `iac/airflow/airflow_db.ddl` (2 occurrences).
- PostgreSQL does not support `IF NOT EXISTS` for these statements (same bug class as #129 for `CREATE DATABASE`).
- Add re-run note to `iam.sql` docstring and fix minor punctuation issues in prerequisites.

## Test plan

- [x] Verified `CREATE ROLE IF NOT EXISTS` errors on PostgreSQL 17.5 locally.
- [ ] Verify `psql -f dags/iam.sql` runs cleanly on a fresh database.