### PR TITLE
docs: clarify spacing rule for docstrings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -210,7 +210,7 @@ The hooks are configured in the [`.pre-commit-config.yaml`](.pre-commit-config.y
 - **Two blank lines**: After imports, before first class/function.
 - **Two blank lines**: Between classes and top-level functions.
 - **One blank line**: Between methods within a class.
-- **One blank line**: After docstrings, before code.
+- **One blank line**: After class docstrings, before first attribute or method (PEP 257).
 
 ##### File Structure Example
 


### PR DESCRIPTION
## Summary

- Narrow CONTRIBUTING.md spacing rule from "After docstrings, before code" to "After class docstrings, before first attribute or method (PEP 257)."
- PEP 257 only mandates blank lines after class docstrings; pydocstyle D202 prohibits them after function docstrings. The previous wording was unenforceable by the toolchain (docformatter, Black).