### PR TITLE
chore(cleanup): apply pent-up docformatter changes, fix DO NOTHING SQL typo, exclude .venv

### DIFF
--- a/dags/lib/dag_utils.py
+++ b/dags/lib/dag_utils.py
@@ -49,7 +49,6 @@ def ingest(config: ETLConfig, **context: dict) -> None:
         This parameter is not used in this function but is included to indicate
         the expected signature for replacement callables that may use it.
     """
-
     # Check existence of target directories.
     for state in [DataState.INGEST, DataState.PROCESS, DataState.STORE]:
         dir_path = getattr(config.data_dirs, state.value)
@@ -101,11 +100,12 @@ def ingest(config: ETLConfig, **context: dict) -> None:
 
 def batch(config: ETLConfig, **context: dict) -> list[tuple[FileSet, ...]]:
     """
-    Construct batches of file sets from the content of the 'process' directory. Intended
-    to be used as a PythonOperator callable in the `batch` Airflow task.
+    Construct batches of file sets from the content of the 'process' directory.
 
-    First, construct file sets by grouping files by their timestamp and matching them
-    to a file type pattern.
+    Intended to be used as a PythonOperator callable in the `batch` Airflow task.
+
+    First, construct file sets by grouping files by their timestamp and matching them to
+    a file type pattern.
 
     Then, split the file sets into batches, which will be processed concurrently
     (sequentially within each batch). The cardinality of file sets in each batch is
@@ -113,13 +113,12 @@ def batch(config: ETLConfig, **context: dict) -> list[tuple[FileSet, ...]]:
     pipeline configuration.
 
     :param config: Configuration parameters for Airflow DAGs and pipeline tasks.
-    :param context: `op_kwargs` passed when defining the task in Airflow plus any
+    :param context:`op_kwargs` passed when defining the task in Airflow plus any
         additional Airflow keyword arguments automatically injected by Airflow. This
         parameter is not used in this function but is included to indicate the expected
         signature for replacement callables that may use it.
     :return: Batched file sets.
     """
-
     # ----------------------------------------------------------------------------------
     # Construct file sets
     # ----------------------------------------------------------------------------------
@@ -245,7 +244,6 @@ class Processor(ABC):
         :param extra_processor_init_kwargs: Additional keyword arguments to be passed to
             the processor class when called by process_wrapper function.
         """
-
         self.config = config
         self.dag_run_id = dag_run_id
         self.dag_start_date = dag_start_date
@@ -257,7 +255,6 @@ class Processor(ABC):
         """
         Initialize the ETLResult object.
         """
-
         self.results = ETLResult(
             config=self.config,
             dag_run_id=self.dag_run_id,
@@ -276,7 +273,6 @@ class Processor(ABC):
         Each file set is processed in its own session/transaction for independence and
         resilience.
         """
-
         pg_engine = get_lens_engine(user=self.config.postgres_user)
 
         # Process each file set in its own session/transaction.
@@ -297,7 +293,6 @@ class Processor(ABC):
 
         :param session: SQLAlchemy Session object.
         """
-
         return
 
     def _try_process_file_set(self, file_set: FileSet, session: Session):
@@ -309,7 +304,6 @@ class Processor(ABC):
         :param file_set: FileSet to process.
         :param session: SQLAlchemy Session object.
         """
-
         try:
             LOGGER.info(f"Processing file set:\n{pformat(file_set.file_paths)}")
             self.process_file_set(file_set=file_set, session=session)
@@ -340,7 +334,6 @@ class Processor(ABC):
         :param file_set: FileSet to process.
         :param session: SQLAlchemy Session object.
         """
-
         raise NotImplementedError
 
 
@@ -352,18 +345,18 @@ def process_wrapper(
     **context,
 ) -> None:
     """
-    Wrapper function to process file sets in a batch. Intended to be used as a
-    PythonOperator callable in each `process` Airflow task assigned to each batch of
-    file sets.
+    Wrapper function to process file sets in a batch.
+
+    Intended to be used as a PythonOperator callable in each `process` Airflow task
+    assigned to each batch of file sets.
 
     :param serialized_file_sets: List of serialized file sets in the batch to process.
     :param config: Configuration parameters for Airflow DAGs and pipeline tasks.
     :param dag_run_id: Unique identifier of the Airflow DAG that executed the ETL task.
     :param dag_start_date: Timestamp indicating when the DAG run started.
-    :param context: `op_kwargs` passed when defining the task in Airflow plus any
+    :param context:`op_kwargs` passed when defining the task in Airflow plus any
         additional Airflow keyword arguments automatically injected by Airflow.
     """
-
     # Deserialize file sets from XCom data.
     file_sets = []
     for serialized_file_set in serialized_file_sets:
@@ -398,20 +391,20 @@ def store(
     **context: dict,
 ) -> None:
     """
-    Move all files from the 'process' directory to the 'store' directory. Files that
-    failed processing (according to the ETLResult persisted to the database) are moved
-    to the 'quarantine' directory. Intended to be used as a PythonOperator callable in
-    the `store` Airflow task.
+    Move all files from the 'process' directory to the 'store' directory.
+
+    Files that failed processing (according to the ETLResult persisted to the database)
+    are moved to the 'quarantine' directory. Intended to be used as a PythonOperator
+    callable in the `store` Airflow task.
 
     :param config: Configuration parameters for Airflow DAGs and pipeline tasks.
     :param dag_run_id: Unique identifier of the Airflow DAG that executed the ETL task.
     :param dag_start_date: Timestamp indicating when the DAG run started.
-    :param context: `op_kwargs` passed when defining the task in Airflow plus any
+    :param context:`op_kwargs` passed when defining the task in Airflow plus any
         additional Airflow keyword arguments automatically injected by Airflow. This
         parameter is not used in this function but is included to indicate the expected
         signature for replacement callables that may use it.
     """
-
     # Check existence of target directories.
     for state in [DataState.PROCESS, DataState.STORE, DataState.QUARANTINE]:
         dir_path = getattr(config.data_dirs, state.value)
@@ -465,7 +458,6 @@ def create_dag(config: ETLConfig, apply_default_task_sequence: bool = True) -> D
         sequence.
     :return: An Airflow DAG object configured with the tasks defined in this module.
     """
-
     dag = DAG(**config.dag_args)
 
     with dag:

--- a/dags/lib/etl_config.py
+++ b/dags/lib/etl_config.py
@@ -161,7 +161,6 @@ class ETLConfig:
         validates that max_process_tasks and min_file_sets_in_batch are >= 1. Raises
         ValueError if configuration is invalid.
         """
-
         if not self.dag_id:
             raise ValueError("dag_id must not be empty.")
         if self.max_process_tasks < 1:
@@ -181,7 +180,6 @@ class ETLConfig:
 
         This is useful for logging and debugging purposes.
         """
-
         return (
             f"ETLConfig(dag_id={self.dag_id}, "
             f"pipeline_print_name={self.pipeline_print_name})"

--- a/dags/lib/etl_monitor_utils.py
+++ b/dags/lib/etl_monitor_utils.py
@@ -97,7 +97,6 @@ class ETLResult:
         Read existing ETL results for this DAG run from the database and populate
         `result_records`.
         """
-
         with Session(self.engine) as sess:
             records = (
                 sess.execute(
@@ -137,7 +136,6 @@ class ETLResult:
             encountered during ETL processing.
         :param traceback: Detailed traceback or error message if the ETL task failed.
         """
-
         self.result_records[file_name] = ETLResultRecord(
             file_name=file_name,
             success=success,
@@ -150,7 +148,6 @@ class ETLResult:
         """
         List of successfully processed file records.
         """
-
         return [record for record in self.result_records.values() if record.success]
 
     @property
@@ -158,14 +155,12 @@ class ETLResult:
         """
         List of file records that failed processing.
         """
-
         return [record for record in self.result_records.values() if not record.success]
 
     def submit(self) -> None:
         """
         Write the ETL results to the database using upsert logic.
         """
-
         model_instances = [
             ETLResultSqla(
                 dag_id=self.config.dag_id,
@@ -198,7 +193,6 @@ class ETLResult:
         """
         Equality comparison for ETLResult objects.
         """
-
         if not isinstance(other, ETLResult):
             return False
         return self.result_records == other.result_records

--- a/dags/lib/filesystem_utils.py
+++ b/dags/lib/filesystem_utils.py
@@ -50,7 +50,6 @@ class ETLDataDirectories:
         :param base_dir: Name of the base directory where pipeline data is stored.
         :param create_dirs: Whether to create directories if they don't exist.
         """
-
         self.ingest = self._get_directory_path(base_dir, DataState.INGEST)
         self.process = self._get_directory_path(base_dir, DataState.PROCESS)
         self.quarantine = self._get_directory_path(base_dir, DataState.QUARANTINE)
@@ -70,7 +69,6 @@ class ETLDataDirectories:
         :param data_state: Data state.
         :return: Path object for the directory.
         """
-
         data_dir = os.environ.get("DATA_DIR")
         if not data_dir:
             LOGGER.warning(
@@ -85,7 +83,6 @@ class ETLDataDirectories:
         """
         Create the pipeline data directories for all data states, if they don't exist.
         """
-
         for directory in [self.ingest, self.process, self.quarantine, self.store]:
             if directory:
                 directory.mkdir(parents=True, exist_ok=True)
@@ -133,7 +130,6 @@ class FileSet:
         """
         Return a flat list of file paths in the file set.
         """
-
         file_paths = []
         for file_list in self.files.values():
             file_paths.extend(file_list)
@@ -146,7 +142,6 @@ class FileSet:
         :param enum: File type enum (e.g., GARMIN_FILE_TYPES.SLEEP).
         :return: List of Path objects, or empty list if none found.
         """
-
         return self.files.get(enum, [])
 
     def to_serializable(self) -> Dict[str, List[str]]:
@@ -155,7 +150,6 @@ class FileSet:
 
         :return: Dictionary with file type names as keys and lists of string paths.
         """
-
         serializable = {}
         for file_type, paths in self.files.items():
             # Convert enum to string and Path objects to strings.
@@ -174,7 +168,6 @@ class FileSet:
         :param file_types_enum: The file types enum class to reconstruct keys.
         :return: FileSet instance.
         """
-
         file_set = cls()
         for type_name, path_strings in data.items():
             # Find the enum by name.
@@ -194,7 +187,6 @@ class FileSet:
 
         :return: Total size in bytes.
         """
-
         total_size = 0
         for file_path in self.file_paths:
             if file_path.exists():

--- a/dags/lib/logging_utils.py
+++ b/dags/lib/logging_utils.py
@@ -26,7 +26,6 @@ class AirflowAwareLogger:
 
         :param name: Logger name (typically __name__ of the module).
         """
-
         self.name = name
         self._fallback_logger = logging.getLogger(name)
 
@@ -36,7 +35,6 @@ class AirflowAwareLogger:
 
         :return: Task logger if in Airflow context, otherwise standard logger.
         """
-
         try:
             context = get_current_context()
             return context["task_instance"].log
@@ -48,35 +46,30 @@ class AirflowAwareLogger:
         """
         Log a debug message.
         """
-
         return self._get_logger().debug(msg, *args, **kwargs)
 
     def info(self, msg: Union[str, object], *args, **kwargs) -> None:
         """
         Log an info message.
         """
-
         return self._get_logger().info(msg, *args, **kwargs)
 
     def warning(self, msg: Union[str, object], *args, **kwargs) -> None:
         """
         Log a warning message.
         """
-
         return self._get_logger().warning(msg, *args, **kwargs)
 
     def error(self, msg: Union[str, object], *args, **kwargs) -> None:
         """
         Log an error message.
         """
-
         return self._get_logger().error(msg, *args, **kwargs)
 
     def critical(self, msg: Union[str, object], *args, **kwargs) -> None:
         """
         Log a critical message.
         """
-
         return self._get_logger().critical(msg, *args, **kwargs)
 
 

--- a/dags/lib/sql_utils.py
+++ b/dags/lib/sql_utils.py
@@ -65,7 +65,6 @@ def make_base(
     :param metadata: SQLAlchemy MetaData instance to share across models.
     :return: Declarative base class for ORM models.
     """
-
     _metadata = metadata or MetaData()
 
     class _Base(DeclarativeBase):
@@ -124,7 +123,6 @@ def fkey(schema: str, table_name: str, column_name: str = None) -> ForeignKey:
     :param column_name: Foreign column name, defaults to <table_name>_id.
     :return: ForeignKey object.
     """
-
     return ForeignKey(".".join([schema, table_name, column_name or f"{table_name}_id"]))
 
 
@@ -150,7 +148,6 @@ def get_engine(
     :param echo: Whether to print queries to stdout.
     :return: SQLAlchemy engine for database operations.
     """
-
     # Escape password as described in SQLAlchemy documentation:
     # https://docs.sqlalchemy.org/en/20/core/engines.html#escaping-special-characters
     password = ":" + urllib.parse.quote_plus(password) if password else ""
@@ -183,7 +180,6 @@ def _get_default_docker_host() -> str:
 
     :return: Docker host address (either host.docker.internal or 172.17.0.1).
     """
-
     try:
         # Try to resolve host.docker.internal.
         socket.gethostbyname("host.docker.internal")
@@ -213,7 +209,6 @@ def get_lens_engine(user: str, echo: bool = False) -> Engine:
     :raises RuntimeError: If SQL_CREDENTIALS_DIR not set or credential file
         missing.
     """
-
     sql_credentials_dir = os.getenv("SQL_CREDENTIALS_DIR")
     if not sql_credentials_dir:
         raise RuntimeError(
@@ -285,14 +280,13 @@ def upsert_model_instances(
     :param latest_check_inclusive: If True, use >= comparison for latest_check_column
         instead of >. Defaults to False (strict greater than).
     :param returning_columns: List of column names to return via RETURNING clause. If
-        None, no RETURNING is issued and the function returns None. Matches the
-        behavior of ``_upsert_values``.
+        None, no RETURNING is issued and the function returns None. Matches the behavior
+        of ``_upsert_values``.
     :param chunk_size: Maximum rows per INSERT statement. Clamped internally so the
         total parameter count never exceeds the psycopg3 limit.
     :return: List of SQLAlchemy model instances (with only the requested columns
         populated) if returning_columns is specified, otherwise None.
     """
-
     if not model_instances:
         raise ValueError("`model_instances` list cannot be empty.")
     model = model_instances[0].__class__
@@ -371,7 +365,6 @@ def _upsert_values(
     :return: List of dictionaries with returned values if returning_columns is
         specified, otherwise None.
     """
-
     if on_conflict_update:
         if not conflict_columns:
             raise ValueError(

--- a/dags/pipelines/garmin/batch.py
+++ b/dags/pipelines/garmin/batch.py
@@ -35,7 +35,6 @@ def batch(
     :return: Serialized batches for XCom. Each batch is a single-element tuple containing
         a list of serialized FileSets (dicts mapping file type patterns to file paths).
     """
-
     if config.max_process_tasks <= 0:
         raise ValueError("`max_process_tasks` must be greater than 0.")
 

--- a/dags/pipelines/garmin/constants.py
+++ b/dags/pipelines/garmin/constants.py
@@ -64,7 +64,6 @@ class GarminDataRegistry:
         """
         Register all Garmin Connect data types.
         """
-
         data_types = [
             # Daily Data - Single date parameter: get_method(date_str)
             GarminDataType(
@@ -220,7 +219,6 @@ class GarminDataRegistry:
         :param data_type: GarminDataType to register.
         :raises ValueError: If a data type with the same name already exists.
         """
-
         if data_type.name in self._data_types_by_name:
             raise ValueError(f"Data type with name '{data_type.name}' already exists.")
 
@@ -237,7 +235,6 @@ class GarminDataRegistry:
         :param name: Name of the data type to retrieve.
         :return: GarminDataType if found, None otherwise.
         """
-
         return self._data_types_by_name.get(name)
 
     def get_by_time_param(
@@ -249,7 +246,6 @@ class GarminDataRegistry:
         :param api_method_time_param: API method time parameter.
         :return: List of GarminDataType data types for the specified time param.
         """
-
         return self._data_types_by_time_param[api_method_time_param].copy()
 
     @property
@@ -259,7 +255,6 @@ class GarminDataRegistry:
 
         :return: Copy of all registered data types.
         """
-
         return self._all_data_types.copy()
 
     @property
@@ -278,7 +273,6 @@ class GarminDataRegistry:
 
         :return: List of data types with RANGE time parameter.
         """
-
         return self.get_by_time_param(APIMethodTimeParam.RANGE)
 
     @property
@@ -288,7 +282,6 @@ class GarminDataRegistry:
 
         :return: List of data types with NO_DATE time parameter.
         """
-
         return self.get_by_time_param(APIMethodTimeParam.NO_DATE)
 
 
@@ -308,7 +301,6 @@ def _create_garmin_file_types() -> type:
 
     :return: Enum class with file type patterns for Garmin Connect data pipeline.
     """
-
     patterns = {}
 
     # Add patterns for each data type in registry.

--- a/dags/pipelines/garmin/garmin_client/api.py
+++ b/dags/pipelines/garmin/garmin_client/api.py
@@ -57,8 +57,8 @@ class ActivityDownloadFormat(Enum):
     """
     Supported binary download formats for ``download_activity``.
 
-    The openetl pipeline only ever uses ``ORIGINAL`` (zipped FIT). The other
-    members exist for signature parity with upstream ``python-garminconnect``.
+    The openetl pipeline only ever uses ``ORIGINAL`` (zipped FIT). The other members
+    exist for signature parity with upstream ``python-garminconnect``.
     """
 
     ORIGINAL = auto()
@@ -78,7 +78,6 @@ def _validate_date_format(date_str: str, param_name: str = "date") -> str:
     :raises ValueError: If the input is not a string, has the wrong shape, or does not
         represent a real calendar date.
     """
-
     if not isinstance(date_str, str):
         raise ValueError(f"{param_name} must be a string")
 
@@ -108,10 +107,9 @@ def get_sleep_data(client: "GarminClient", cdate: str) -> Dict[str, Any]:
 
     :param client: GarminClient instance.
     :param cdate: Date in ``YYYY-MM-DD`` format.
-    :return: Sleep data dictionary including sleep stages, scores, HRV, and
-        breathing disruptions.
+    :return: Sleep data dictionary including sleep stages, scores, HRV, and breathing
+        disruptions.
     """
-
     cdate = _validate_date_format(cdate, "cdate")
     url = f"{DAILY_SLEEP_URL}/{client.display_name}"
     params = {"date": cdate, "nonSleepBufferMinutes": 60}
@@ -126,7 +124,6 @@ def get_stress_data(client: "GarminClient", cdate: str) -> Dict[str, Any]:
     :param cdate: Date in ``YYYY-MM-DD`` format.
     :return: Stress data dictionary with 3-minute interval time series.
     """
-
     cdate = _validate_date_format(cdate, "cdate")
     url = f"{DAILY_STRESS_URL}/{cdate}"
     return client._connectapi(url)
@@ -141,7 +138,6 @@ def get_respiration_data(client: "GarminClient", cdate: str) -> Dict[str, Any]:
     :return: Respiration dictionary with 2-minute interval and 1-hour aggregate
         readings.
     """
-
     cdate = _validate_date_format(cdate, "cdate")
     url = f"{DAILY_RESPIRATION_URL}/{cdate}"
     return client._connectapi(url)
@@ -155,7 +151,6 @@ def get_heart_rates(client: "GarminClient", cdate: str) -> Dict[str, Any]:
     :param cdate: Date in ``YYYY-MM-DD`` format.
     :return: Heart rate dictionary with 2-minute interval time series.
     """
-
     cdate = _validate_date_format(cdate, "cdate")
     url = f"{HEART_RATES_DAILY_URL}/{client.display_name}"
     params = {"date": cdate}
@@ -170,7 +165,6 @@ def get_training_readiness(client: "GarminClient", cdate: str) -> List[Dict[str,
     :param cdate: Date in ``YYYY-MM-DD`` format.
     :return: List of training readiness score dictionaries for the day.
     """
-
     cdate = _validate_date_format(cdate, "cdate")
     url = f"{TRAINING_READINESS_URL}/{cdate}"
     return client._connectapi(url)
@@ -182,10 +176,8 @@ def get_training_status(client: "GarminClient", cdate: str) -> Dict[str, Any]:
 
     :param client: GarminClient instance.
     :param cdate: Date in ``YYYY-MM-DD`` format.
-    :return: Training status dictionary including VO2 max, training load, and
-        ACWR.
+    :return: Training status dictionary including VO2 max, training load, and ACWR.
     """
-
     cdate = _validate_date_format(cdate, "cdate")
     url = f"{TRAINING_STATUS_URL}/{cdate}"
     return client._connectapi(url)
@@ -195,15 +187,14 @@ def get_steps_data(client: "GarminClient", cdate: str) -> List[Dict[str, Any]]:
     """
     Fetch steps data for the given date.
 
-    Returns an empty list when the API returns ``None`` (e.g. for dates with no
-    sync history). This matches upstream ``python-garminconnect`` behavior so the
-    openetl pipeline's downstream filtering is unchanged.
+    Returns an empty list when the API returns ``None`` (e.g. for dates with no sync
+    history). This matches upstream ``python-garminconnect`` behavior so the openetl
+    pipeline's downstream filtering is unchanged.
 
     :param client: GarminClient instance.
     :param cdate: Date in ``YYYY-MM-DD`` format.
     :return: List of 15-minute steps interval dictionaries, or an empty list.
     """
-
     cdate = _validate_date_format(cdate, "cdate")
     url = f"{USER_SUMMARY_CHART_URL}/{client.display_name}"
     params = {"date": cdate}
@@ -221,7 +212,6 @@ def get_floors(client: "GarminClient", cdate: str) -> Dict[str, Any]:
     :param cdate: Date in ``YYYY-MM-DD`` format.
     :return: Floors dictionary with 15-minute interval time series.
     """
-
     cdate = _validate_date_format(cdate, "cdate")
     url = f"{FLOORS_CHART_DAILY_URL}/{cdate}"
     return client._connectapi(url)
@@ -236,7 +226,6 @@ def get_intensity_minutes_data(client: "GarminClient", cdate: str) -> Dict[str, 
     :return: Intensity minutes dictionary with weekly and daily moderate/vigorous
         breakdown.
     """
-
     cdate = _validate_date_format(cdate, "cdate")
     url = f"{DAILY_INTENSITY_MINUTES_URL}/{cdate}"
     return client._connectapi(url)
@@ -264,13 +253,12 @@ def get_activities_by_date(
     :param startdate: Start date in ``YYYY-MM-DD`` format.
     :param enddate: Optional end date in ``YYYY-MM-DD`` format.
     :param activitytype: Optional activity type filter (``cycling``, ``running``,
-        ``swimming``, ``multi_sport``, ``fitness_equipment``, ``hiking``,
-        ``walking``, ``other``).
+        ``swimming``, ``multi_sport``, ``fitness_equipment``, ``hiking``, ``walking``,
+        ``other``).
     :param sortorder: Optional sort direction (``asc`` to override the default
         descending order).
     :return: List of activity dictionaries.
     """
-
     activities: List[Dict[str, Any]] = []
     start = 0
     limit = 20
@@ -311,11 +299,10 @@ def get_activity_exercise_sets(
 
     :param client: GarminClient instance.
     :param activity_id: Garmin activity ID (numeric or string-encoded numeric).
-    :return: Exercise sets dictionary with ML-classified exercises, reps,
-        weights, and set types.
+    :return: Exercise sets dictionary with ML-classified exercises, reps, weights, and
+        set types.
     :raises ValueError: If ``activity_id`` is not a positive integer.
     """
-
     aid = int(activity_id)
     if aid <= 0:
         raise ValueError(f"activity_id must be a positive integer, got {activity_id}")
@@ -336,7 +323,6 @@ def get_personal_record(client: "GarminClient") -> Dict[str, Any]:
     :return: Personal records dictionary covering steps, running, cycling, swimming, and
         strength.
     """
-
     url = f"{PERSONAL_RECORD_URL}/{client.display_name}"
     return client._connectapi(url)
 
@@ -365,7 +351,6 @@ def get_race_predictions(
     :raises ValueError: For invalid ``_type``, partial parameter sets, or ranges
         longer than one year.
     """
-
     valid = {"daily", "monthly", None}
     if _type not in valid:
         raise ValueError(f"_type must be one of {valid!r}")
@@ -401,7 +386,6 @@ def get_user_profile(client: "GarminClient") -> Dict[str, Any]:
     :return: User settings dictionary including ``id``, gender, weight, height,
         birthday, and threshold metrics.
     """
-
     return client._connectapi(USER_SETTINGS_URL)
 
 
@@ -418,9 +402,8 @@ def download_activity(
     """
     Download an activity file in the requested binary format.
 
-    The ``ORIGINAL`` format returns a zipped FIT file (the openetl pipeline
-    extracts the FIT inside). The other formats return their respective
-    serialized representations.
+    The ``ORIGINAL`` format returns a zipped FIT file (the openetl pipeline extracts the
+    FIT inside). The other formats return their respective serialized representations.
 
     :param client: GarminClient instance.
     :param activity_id: Garmin activity ID.
@@ -428,7 +411,6 @@ def download_activity(
     :return: Raw bytes of the downloaded file.
     :raises ValueError: If ``dl_fmt`` is not a supported format.
     """
-
     aid = str(activity_id)
     urls = {
         ActivityDownloadFormat.ORIGINAL: f"{FIT_DOWNLOAD_URL}/{aid}",

--- a/dags/pipelines/garmin/garmin_client/client.py
+++ b/dags/pipelines/garmin/garmin_client/client.py
@@ -115,7 +115,6 @@ class GarminClient:
         :param kwargs: Optional ``pool_connections`` and ``pool_maxsize`` for the
             requests adapter when curl_cffi is unavailable.
         """
-
         self.domain = domain
         self._sso = f"https://sso.{domain}"
         self._connect = f"https://connect.{domain}"
@@ -151,15 +150,13 @@ class GarminClient:
         """
         Load tokens from disk, populate profile state, and return a ready client.
 
-        :param token_dir: Directory containing ``garmin_tokens.json``, or a
-            direct path to that file.
+        :param token_dir: Directory containing ``garmin_tokens.json``, or a direct path
+            to that file.
         :return: Authenticated GarminClient ready to make API calls.
-        :raises GarminConnectionError: If the token file is missing or
-            unreadable.
-        :raises GarminAuthenticationError: If the token file contains no token,
-            or if the profile fetch fails.
+        :raises GarminConnectionError: If the token file is missing or unreadable.
+        :raises GarminAuthenticationError: If the token file contains no token, or if
+            the profile fetch fails.
         """
-
         client = cls()
         client.load(token_dir)
         client._load_profile()
@@ -174,7 +171,6 @@ class GarminClient:
         """
         :return: True if a DI access token is currently held.
         """
-
         return bool(self.di_token)
 
     def get_api_headers(self) -> Dict[str, str]:
@@ -184,7 +180,6 @@ class GarminClient:
         :return: Dictionary including the Bearer token and native UA headers.
         :raises GarminAuthenticationError: If no token is held.
         """
-
         if not self.is_authenticated:
             raise GarminAuthenticationError("Not authenticated")
         return _native_headers(
@@ -238,7 +233,6 @@ class GarminClient:
         :raises GarminConnectionError: When all strategies fail with non-auth
             errors.
         """
-
         # Clear any leftover MFA state from a prior abandoned login attempt so
         # resume_login doesn't incorrectly route to a stale strategy.
         for attr in (
@@ -329,17 +323,16 @@ class GarminClient:
         """
         Complete an MFA challenge that was paused via ``return_on_mfa=True``.
 
-        Routes to the appropriate MFA completion function based on which login
-        strategy stashed its session state on the client.
+        Routes to the appropriate MFA completion function based on which login strategy
+        stashed its session state on the client.
 
-        :param _client_state: Opaque session token returned by ``login()`` (kept
-            for signature parity with the upstream library; resume routes via
-            attribute presence on the client instance, not via this argument).
+        :param _client_state: Opaque session token returned by ``login()`` (kept for
+            signature parity with the upstream library; resume routes via attribute
+            presence on the client instance, not via this argument).
         :param mfa_code: 6-digit MFA code.
-        :return: ``(None, None)`` on success.
+        :return:``(None, None)`` on success.
         :raises GarminAuthenticationError: On verification failure.
         """
-
         if hasattr(self, "_widget_session"):
             ticket = strategies.complete_mfa_widget(self, mfa_code)
             sso_embed = f"{self._sso}/sso/embed"
@@ -377,18 +370,16 @@ class GarminClient:
         """
         Consume a CAS service ticket by exchanging it for DI OAuth2 tokens.
 
-        Unlike the upstream library, this client does not fall back to
-        ``JWT_WEB`` cookie auth: DI Bearer tokens have worked exclusively for
-        months and the JWT_WEB path is dead code we don't want to maintain.
+        Unlike the upstream library, this client does not fall back to ``JWT_WEB``
+        cookie auth: DI Bearer tokens have worked exclusively for months and the JWT_WEB
+        path is dead code we don't want to maintain.
 
         :param ticket: CAS service ticket from the SSO login flow.
-        :param sess: Optional session that originated the ticket (kept for
-            interface parity; the DI token exchange uses its own HTTP client).
+        :param sess: Optional session that originated the ticket (kept for interface
+            parity; the DI token exchange uses its own HTTP client).
         :param service_url: SSO service URL the ticket was issued for.
-        :raises GarminAuthenticationError: If the DI exchange fails on all
-            client IDs.
+        :raises GarminAuthenticationError: If the DI exchange fails on all client IDs.
         """
-
         # sess is intentionally accepted but unused: the DI token exchange
         # speaks a different protocol (OAuth2 over diauth.garmin.com) and does
         # not consume CAS cookies from the SSO login session.
@@ -400,10 +391,9 @@ class GarminClient:
         """
         POST helper using curl_cffi if installed, plain requests otherwise.
 
-        Used by the DI token exchange and refresh, both of which post directly
-        to ``diauth.garmin.com`` (no SSO cookies required).
+        Used by the DI token exchange and refresh, both of which post directly to
+        ``diauth.garmin.com`` (no SSO cookies required).
         """
-
         if HAS_CFFI:
             return cffi_requests.post(url, impersonate="chrome", **kwargs)
         return requests.post(url, **kwargs)  # noqa: S113
@@ -427,7 +417,6 @@ class GarminClient:
         :raises GarminAuthenticationError: If exchange fails on all client IDs for non-
             transport reasons (HTTP error, malformed response, missing token).
         """
-
         svc_url = service_url or MOBILE_SSO_SERVICE_URL
 
         di_token = None
@@ -509,18 +498,16 @@ class GarminClient:
         """
         Refresh the DI access token using the stored refresh token.
 
-        Garmin rotates the refresh token on each use, so the response includes
-        a new refresh token that replaces the old one. The caller is responsible
-        for persisting the new pair to disk via :meth:`_refresh_session`.
+        Garmin rotates the refresh token on each use, so the response includes a new
+        refresh token that replaces the old one. The caller is responsible for
+        persisting the new pair to disk via :meth:`_refresh_session`.
 
-        :raises GarminAuthenticationError: If no refresh token is held, or the
-            server rejects it.
-        :raises GarminTooManyRequestsError: If the DI token endpoint returns
-            HTTP 429.
-        :raises GarminConnectionError: On transport errors (connection,
-            timeout, SSL) or non-JSON responses.
+        :raises GarminAuthenticationError: If no refresh token is held, or the server
+            rejects it.
+        :raises GarminTooManyRequestsError: If the DI token endpoint returns HTTP 429.
+        :raises GarminConnectionError: On transport errors (connection, timeout, SSL) or
+            non-JSON responses.
         """
-
         if not self.di_refresh_token or not self.di_client_id:
             raise GarminAuthenticationError("No DI refresh token available")
         try:
@@ -591,7 +578,6 @@ class GarminClient:
         :param token: JWT access token.
         :return: Client ID string, or None if the token cannot be parsed.
         """
-
         try:
             parts = token.split(".")
             if len(parts) < 2:
@@ -607,7 +593,6 @@ class GarminClient:
         """
         :return: True if the current access token expires within 15 minutes.
         """
-
         token = self.di_token
         if not token:
             return False
@@ -629,12 +614,10 @@ class GarminClient:
         """
         Refresh the DI access token and persist the new pair to disk.
 
-        Called automatically by :meth:`_request` when the token is near expiry
-        or when an API call returns 401. The persistence step is best-effort:
-        a failure to write the new tokens to disk does not block the in-memory
-        refresh from succeeding.
+        Called automatically by :meth:`_request` when the token is near expiry or when
+        an API call returns 401. The persistence step is best-effort: a failure to write
+        the new tokens to disk does not block the in-memory refresh from succeeding.
         """
-
         if not self.di_token:
             return
         try:
@@ -666,7 +649,6 @@ class GarminClient:
         :raises GarminAuthenticationError: If the profile response is missing
             ``displayName``.
         """
-
         profile = self._connectapi(SOCIAL_PROFILE_URL)
         if not profile or "displayName" not in profile:
             raise GarminAuthenticationError("Profile response missing displayName")
@@ -688,7 +670,6 @@ class GarminClient:
         :raises GarminConnectionError: If the response body is not valid JSON
             (e.g., a Cloudflare HTML edge page returned with a 200 status).
         """
-
         resp = self._request("GET", path, **kwargs)
         if resp.status_code == 204:
             return {}
@@ -710,7 +691,6 @@ class GarminClient:
         :param path: API path.
         :return: Raw response bytes.
         """
-
         headers = kwargs.pop("headers", {})
         headers["Accept"] = "*/*"
         return self._request("GET", path, headers=headers, **kwargs).content
@@ -739,7 +719,6 @@ class GarminClient:
             defaults to 15s.
         :return: The successful response object.
         """
-
         if self.is_authenticated and self._token_expires_soon():
             self._refresh_session()
 
@@ -814,7 +793,6 @@ class GarminClient:
 
     def dumps(self) -> str:
         """:return: JSON string of the current DI token state."""
-
         return tokens.dumps(self)
 
     def dump(self, path: Union[str, Path]) -> None:
@@ -823,7 +801,6 @@ class GarminClient:
 
         :param path: Directory or ``.json`` file path.
         """
-
         tokens.dump(self, path)
 
     def loads(self, tokenstore: str) -> None:
@@ -833,25 +810,22 @@ class GarminClient:
         :param tokenstore: JSON string with ``di_token``, ``di_refresh_token``,
             ``di_client_id``.
         """
-
         tokens.loads(self, tokenstore)
 
     def load(self, path: Union[str, Path]) -> None:
         """
         Replace current DI tokens with the ones loaded from disk.
 
-        Records the resolved path so that subsequent token refreshes persist
-        back to the same file.
+        Records the resolved path so that subsequent token refreshes persist back to the
+        same file.
 
         :param path: Directory or ``.json`` file path.
         """
-
         tokens.load(self, path)
 
     # ------------------------------------------------------------------
     # API method bindings (delegate to api module)
     # ------------------------------------------------------------------
-
     # Defined as bound methods (not lambdas) so they show up correctly in
     # introspection / autocomplete and so getattr-based dispatch in
     # extract.py keeps working.

--- a/dags/pipelines/garmin/garmin_client/constants.py
+++ b/dags/pipelines/garmin/garmin_client/constants.py
@@ -143,7 +143,6 @@ def _random_browser_headers() -> Dict[str, str]:
 
     :return: Dictionary of browser-style HTTP headers.
     """
-
     if HAS_UA_GEN:
         ua = _generate_ua()
         return dict(ua.headers.get())
@@ -159,7 +158,6 @@ def _build_basic_auth(client_id: str) -> str:
     :param client_id: DI OAuth2 client identifier.
     :return: Basic auth header value (including the ``Basic `` prefix).
     """
-
     return "Basic " + base64.b64encode(f"{client_id}:".encode()).decode()
 
 
@@ -170,7 +168,6 @@ def _native_headers(extra: Optional[Dict[str, str]] = None) -> Dict[str, str]:
     :param extra: Optional extra headers to merge on top of the native defaults.
     :return: Dictionary of HTTP headers.
     """
-
     headers: Dict[str, str] = {
         "User-Agent": NATIVE_API_USER_AGENT,
         "X-Garmin-User-Agent": NATIVE_X_GARMIN_USER_AGENT,

--- a/dags/pipelines/garmin/garmin_client/exceptions.py
+++ b/dags/pipelines/garmin/garmin_client/exceptions.py
@@ -34,7 +34,7 @@ class GarminTooManyRequestsError(GarminConnectionError):
     """
     Garmin or Cloudflare returned HTTP 429.
 
-    Subclass of ``GarminConnectionError`` so callers that want to handle all
-    connection problems uniformly can catch the parent class while callers that
-    care about rate limiting specifically can catch this subclass.
+    Subclass of ``GarminConnectionError`` so callers that want to handle all connection
+    problems uniformly can catch the parent class while callers that care about rate
+    limiting specifically can catch this subclass.
     """

--- a/dags/pipelines/garmin/garmin_client/strategies.py
+++ b/dags/pipelines/garmin/garmin_client/strategies.py
@@ -107,7 +107,6 @@ def widget_login_cffi(
     :raises GarminAuthenticationError: On invalid credentials or missing MFA prompt.
     :raises GarminConnectionError: On HTTP errors or unexpected page contents.
     """
-
     if not HAS_CFFI:
         raise GarminConnectionError("curl_cffi not installed; widget+cffi unavailable")
 
@@ -233,7 +232,6 @@ def complete_mfa_widget(client: Any, mfa_code: str) -> str:
     :raises GarminTooManyRequestsError: On HTTP 429.
     :raises GarminConnectionError: On HTTP errors.
     """
-
     sess = client._widget_session
     r = client._widget_last_resp
 
@@ -288,18 +286,17 @@ def portal_web_login_cffi(
     """
     Log in via the portal web endpoint using curl_cffi TLS impersonation.
 
-    Tries five browser TLS fingerprints in order. Safari is less likely to be
-    blocked by Cloudflare than Chrome.
+    Tries five browser TLS fingerprints in order. Safari is less likely to be blocked by
+    Cloudflare than Chrome.
 
     :param client: GarminClient instance.
     :param email: Garmin Connect email.
     :param password: Garmin Connect password.
     :param prompt_mfa: Callable returning a 6-digit MFA code (see widget flow).
     :param return_on_mfa: If True, return early on MFA challenge.
-    :return: ``(None, None)`` on success, or ``("needs_mfa", session)`` on MFA.
+    :return:``(None, None)`` on success, or ``("needs_mfa", session)`` on MFA.
     :raises GarminConnectionError: If all five impersonations fail.
     """
-
     if not HAS_CFFI:
         raise GarminConnectionError("curl_cffi not installed; portal+cffi unavailable")
 
@@ -359,19 +356,17 @@ def portal_web_login_requests(
     """
     Log in via the portal web endpoint using plain ``requests``.
 
-    Acts as a no-curl_cffi fallback for the portal flow. Browser-style headers
-    (random User-Agent + sec-ch-ua) are generated inside ``_portal_web_login``
-    and passed explicitly on each request, so no session-level headers are set
-    here.
+    Acts as a no-curl_cffi fallback for the portal flow. Browser-style headers (random
+    User-Agent + sec-ch-ua) are generated inside ``_portal_web_login`` and passed
+    explicitly on each request, so no session-level headers are set here.
 
     :param client: GarminClient instance.
     :param email: Garmin Connect email.
     :param password: Garmin Connect password.
     :param prompt_mfa: Callable returning a 6-digit MFA code.
     :param return_on_mfa: If True, return early on MFA challenge.
-    :return: ``(None, None)`` on success, or ``("needs_mfa", session)`` on MFA.
+    :return:``(None, None)`` on success, or ``("needs_mfa", session)`` on MFA.
     """
-
     sess = requests.Session()
     return _portal_web_login(
         client,
@@ -394,11 +389,11 @@ def _portal_web_login(
     """
     Shared portal web login implementation used by the cffi and requests variants.
 
-    Hits ``/portal/api/login``, which is the same endpoint the Garmin Connect
-    React app uses. Cloudflare cannot block it without breaking the website
-    itself, but it does rate-limit consecutive GET+POST without intervening
-    delay. The 30-45s sleep between Step 1 and Step 2 mimics natural browser
-    behavior and consistently avoids the 429 block.
+    Hits ``/portal/api/login``, which is the same endpoint the Garmin Connect React app
+    uses. Cloudflare cannot block it without breaking the website itself, but it does
+    rate-limit consecutive GET+POST without intervening delay. The 30-45s sleep between
+    Step 1 and Step 2 mimics natural browser behavior and consistently avoids the 429
+    block.
 
     :param client: GarminClient instance.
     :param sess: Pre-built session (cffi or plain requests).
@@ -406,12 +401,11 @@ def _portal_web_login(
     :param password: Garmin Connect password.
     :param prompt_mfa: Callable returning a 6-digit MFA code.
     :param return_on_mfa: If True, return early on MFA challenge.
-    :return: ``(None, None)`` on success, or ``("needs_mfa", session)`` on MFA.
+    :return:``(None, None)`` on success, or ``("needs_mfa", session)`` on MFA.
     :raises GarminTooManyRequestsError: On HTTP 429.
     :raises GarminAuthenticationError: On invalid credentials or missing MFA prompt.
     :raises GarminConnectionError: On HTTP errors or unexpected response shape.
     """
-
     signin_url = f"{client._sso}/portal/sso/en-US/sign-in"
 
     # Generate a consistent random browser identity for this login attempt.
@@ -536,21 +530,20 @@ def complete_mfa_portal_web(client: Any, mfa_code: str) -> None:
     """
     Complete MFA via the portal web flow.
 
-    Tries ``/portal/api/mfa/verifyCode`` first, then ``/mobile/api/mfa/verifyCode``
-    as a fallback. Both share the SSO session cookies, but Garmin occasionally
-    routes one or the other through a different rate limit bucket, so trying
-    both gives the best success rate.
+    Tries ``/portal/api/mfa/verifyCode`` first, then ``/mobile/api/mfa/verifyCode`` as a
+    fallback. Both share the SSO session cookies, but Garmin occasionally routes one or
+    the other through a different rate limit bucket, so trying both gives the best
+    success rate.
 
     :param client: GarminClient instance with portal web MFA state.
     :param mfa_code: 6-digit MFA code.
-    :raises GarminTooManyRequestsError: If every attempted endpoint returned HTTP 429
-        or a 429 in the JSON body (pure rate-limit aggregate).
+    :raises GarminTooManyRequestsError: If every attempted endpoint returned HTTP 429 or
+        a 429 in the JSON body (pure rate-limit aggregate).
     :raises GarminConnectionError: If every attempted endpoint failed with a
         transport/non-JSON error (pure infrastructure aggregate).
     :raises GarminAuthenticationError: If at least one endpoint returned a parseable
         non-SUCCESSFUL response (definitive verification failure).
     """
-
     sess = client._mfa_portal_web_session
     mfa_json = {
         "mfaMethod": getattr(client, "_mfa_method", "email"),
@@ -674,21 +667,20 @@ def portal_login(
     """
     Log in via the mobile SSO API using curl_cffi for TLS impersonation.
 
-    This is the Android Garmin Connect Mobile app flow. Used as a fallback when
-    the web portal flows are blocked.
+    This is the Android Garmin Connect Mobile app flow. Used as a fallback when the web
+    portal flows are blocked.
 
     :param client: GarminClient instance.
     :param email: Garmin Connect email.
     :param password: Garmin Connect password.
     :param prompt_mfa: Callable returning a 6-digit MFA code.
     :param return_on_mfa: If True, return early on MFA challenge.
-    :return: ``(None, None)`` on success, or ``("needs_mfa", session)`` on MFA.
+    :return:``(None, None)`` on success, or ``("needs_mfa", session)`` on MFA.
     :raises GarminTooManyRequestsError: On HTTP 429.
     :raises GarminAuthenticationError: On bad credentials or unexpected status.
-    :raises GarminConnectionError: If curl_cffi is unavailable, on non-OK
-        responses, or on non-JSON response bodies.
+    :raises GarminConnectionError: If curl_cffi is unavailable, on non-OK responses, or
+        on non-JSON response bodies.
     """
-
     if not HAS_CFFI:
         raise GarminConnectionError("curl_cffi not installed; mobile+cffi unavailable")
 
@@ -811,7 +803,6 @@ def complete_mfa_portal(client: Any, mfa_code: str) -> None:
         (server/transport error, not a verification failure).
     :raises GarminAuthenticationError: On a parsed non-SUCCESSFUL verification response.
     """
-
     sess = client._mfa_cffi_session
     r = sess.post(
         f"{client._sso}/mobile/api/mfa/verifyCode",
@@ -861,22 +852,21 @@ def mobile_login(
     """
     Log in via the mobile SSO API using plain ``requests``.
 
-    No TLS impersonation. Position 4 of 5 in the strategy chain, ahead of only
-    the widget+cffi last-resort. Likely to be 429'd by Cloudflare without TLS
-    impersonation, but occasionally succeeds when the cffi-based portal and
-    mobile flows have been blocked on the current IP.
+    No TLS impersonation. Position 4 of 5 in the strategy chain, ahead of only the
+    widget+cffi last-resort. Likely to be 429'd by Cloudflare without TLS impersonation,
+    but occasionally succeeds when the cffi-based portal and mobile flows have been
+    blocked on the current IP.
 
     :param client: GarminClient instance.
     :param email: Garmin Connect email.
     :param password: Garmin Connect password.
     :param prompt_mfa: Callable returning a 6-digit MFA code.
     :param return_on_mfa: If True, return early on MFA challenge.
-    :return: ``(None, None)`` on success, or ``("needs_mfa", session)`` on MFA.
+    :return:``(None, None)`` on success, or ``("needs_mfa", session)`` on MFA.
     :raises GarminTooManyRequestsError: On HTTP 429.
     :raises GarminAuthenticationError: On bad credentials.
     :raises GarminConnectionError: On non-JSON response.
     """
-
     sess = requests.Session()
     sess.headers.update(
         {
@@ -992,7 +982,6 @@ def complete_mfa(client: Any, mfa_code: str) -> None:
         (server/transport error, not a verification failure).
     :raises GarminAuthenticationError: On a parsed non-SUCCESSFUL verification response.
     """
-
     r = client._mfa_session.post(
         f"{client._sso}/mobile/api/mfa/verifyCode",
         params={

--- a/dags/pipelines/garmin/garmin_client/tokens.py
+++ b/dags/pipelines/garmin/garmin_client/tokens.py
@@ -36,7 +36,6 @@ def dumps(client: "GarminClient") -> str:
     :param client: GarminClient with populated DI fields.
     :return: JSON string with ``di_token``, ``di_refresh_token``, ``di_client_id``.
     """
-
     data = {
         "di_token": client.di_token,
         "di_refresh_token": client.di_refresh_token,
@@ -49,16 +48,15 @@ def dump(client: "GarminClient", path: Union[str, Path]) -> None:
     """
     Write a client's DI tokens to disk as ``garmin_tokens.json``.
 
-    Accepts either a directory (in which case ``garmin_tokens.json`` is appended)
-    or a ``.json`` file path. Creates parent directories as needed. The file mode
-    is forced to ``0o600`` on every write so the secret tokens are never readable
-    by other users, even if the file is freshly created (umask) or if a caller
-    forgets to chmod after the initial bootstrap.
+    Accepts either a directory (in which case ``garmin_tokens.json`` is appended) or a
+    ``.json`` file path. Creates parent directories as needed. The file mode is forced
+    to ``0o600`` on every write so the secret tokens are never readable by other users,
+    even if the file is freshly created (umask) or if a caller forgets to chmod after
+    the initial bootstrap.
 
     :param client: GarminClient with populated DI fields.
     :param path: Directory or ``.json`` file path.
     """
-
     p = Path(path).expanduser()
     if p.is_dir() or not p.name.endswith(".json"):
         p = p / "garmin_tokens.json"
@@ -87,7 +85,6 @@ def loads(client: "GarminClient", tokenstore: str) -> None:
     :raises GarminConnectionError: If the JSON is malformed.
     :raises GarminAuthenticationError: If the JSON parses but contains no token.
     """
-
     try:
         data = json.loads(tokenstore)
     except Exception as e:
@@ -117,16 +114,15 @@ def load(client: "GarminClient", path: Union[str, Path]) -> None:
     """
     Load DI tokens into a client from disk.
 
-    Accepts either a directory containing ``garmin_tokens.json`` or a direct
-    ``.json`` file path. Records the resolved path on the client so that
-    subsequent token refreshes can persist back to the same file.
+    Accepts either a directory containing ``garmin_tokens.json`` or a direct ``.json``
+    file path. Records the resolved path on the client so that subsequent token
+    refreshes can persist back to the same file.
 
     :param client: GarminClient to populate.
     :param path: Directory or ``.json`` file path.
-    :raises GarminConnectionError: If the file is missing or unreadable, or if
-        the JSON is malformed.
+    :raises GarminConnectionError: If the file is missing or unreadable, or if the JSON
+        is malformed.
     """
-
     try:
         p = Path(path).expanduser()
         if p.is_dir() or not p.name.endswith(".json"):

--- a/dags/pipelines/garmin/process.py
+++ b/dags/pipelines/garmin/process.py
@@ -92,7 +92,6 @@ class GarminProcessor(Processor):
         :param file_set: FileSet containing Garmin data files to process.
         :param session: SQLAlchemy Session object.
         """
-
         # Extract `user_id` from the first file and set instance attribute.
         # All files in a file set have same `user_id` and `timestamp`.
         first_file = file_set.file_paths[0]
@@ -178,7 +177,6 @@ class GarminProcessor(Processor):
         :param file_path: Path to the JSON file to load.
         :return: Parsed JSON data as a dictionary.
         """
-
         with open(file_path, "r", encoding="utf-8") as f:
             return json.load(f)
 
@@ -196,7 +194,6 @@ class GarminProcessor(Processor):
         :return: Dictionary with `user_id`, `data_type`, and `timestamp`.
         :raises ValueError: If filename doesn't match expected pattern.
         """
-
         pattern = r"^(\d+)_([A-Z_]+)(?:_\d+)?_([0-9T:\-Z\.]+)\.(json|fit)$"
         match = re.match(pattern, filename)
 
@@ -220,7 +217,6 @@ class GarminProcessor(Processor):
         :param field_name: Field name in camelCase.
         :return: Field name in snake_case.
         """
-
         # Insert underscore before capital letters and convert to lowercase.
         snake_case = re.sub(r"(?<!^)(?=[A-Z])", "_", field_name).lower()
         return snake_case
@@ -235,7 +231,6 @@ class GarminProcessor(Processor):
         :param user_id: User ID to check and create if necessary.
         :param session: SQLAlchemy Session object.
         """
-
         # Check if user exists in user table.
         existing_user = (
             session.execute(select(User).where(User.user_id == int(user_id)))
@@ -246,11 +241,11 @@ class GarminProcessor(Processor):
         if not existing_user:
             # Create minimal user record with conflict handling.
             session.execute(
-                text("""
-                INSERT INTO garmin.user (user_id, full_name, birth_date) 
-                VALUES (:user_id, NULL, NULL) 
-                ON CONFLICT (user_id) DO NOTHING
-            """),
+                text(
+                    "INSERT INTO garmin.user (user_id, full_name, birth_date) "
+                    "VALUES (:user_id, NULL, NULL) "
+                    "ON CONFLICT (user_id) DO NOTHING"
+                ),
                 {"user_id": int(user_id)},
             )
             session.flush()
@@ -274,7 +269,6 @@ class GarminProcessor(Processor):
         :param file_path: Path to the user profile JSON file.
         :param session: SQLAlchemy Session object.
         """
-
         # Load and parse the JSON data.
         data = self._load_json_file(file_path)
         profile_data = data["userData"]
@@ -365,7 +359,6 @@ class GarminProcessor(Processor):
         :param file_path: Path to the activities list JSON file.
         :param session: SQLAlchemy Session object.
         """
-
         # Load and parse the JSON data.
         activities_list = self._load_json_file(file_path)
 
@@ -385,7 +378,6 @@ class GarminProcessor(Processor):
         :param activity_data: Activity data from JSON.
         :param session: SQLAlchemy Session object.
         """
-
         # Determine activity type for sport-specific processing.
         activity_type_key = (
             activity_data.get("activityType", {}).get("typeKey", "").lower()
@@ -429,7 +421,6 @@ class GarminProcessor(Processor):
         :param session: SQLAlchemy Session object.
         :return: Activity ID from the processed record.
         """
-
         # Extract activity ID.
         activity_id = activity_data.pop("activityId")
 
@@ -599,7 +590,6 @@ class GarminProcessor(Processor):
         :param activity_id: Activity ID for foreign key reference.
         :param session: SQLAlchemy Session object.
         """
-
         # Extract fields requiring custom mapping first (all nullable).
         swimming_metrics = {
             "avg_swim_cadence": activity_data.pop(
@@ -649,7 +639,6 @@ class GarminProcessor(Processor):
         :param activity_id: Activity ID for foreign key reference.
         :param session: SQLAlchemy Session object.
         """
-
         # Extract fields requiring custom mapping first (all nullable).
         cycling_metrics = {
             "vo2_max_value": activity_data.pop("vO2MaxValue", None),
@@ -733,7 +722,6 @@ class GarminProcessor(Processor):
         :param activity_id: Activity ID for foreign key reference.
         :param session: SQLAlchemy Session object.
         """
-
         # Extract fields requiring custom mapping first (all nullable).
         running_metrics = {
             "vo2_max_value": activity_data.pop("vO2MaxValue", None),
@@ -806,7 +794,6 @@ class GarminProcessor(Processor):
         :param activity_id: Activity ID for foreign key reference.
         :param session: SQLAlchemy Session object.
         """
-
         # Pop strength-specific fields to prevent supplemental leakage.
         summarized_sets = activity_data.pop("summarizedExerciseSets", None)
         activity_data.pop("totalSets", None)
@@ -867,7 +854,6 @@ class GarminProcessor(Processor):
         :param file_path: Path to the EXERCISE_SETS JSON file.
         :param session: SQLAlchemy Session object.
         """
-
         with open(file_path, "r", encoding="utf-8") as f:
             data = json.load(f)
 
@@ -960,9 +946,7 @@ class GarminProcessor(Processor):
         :param activity_id: Activity ID for foreign key reference.
         :param session: SQLAlchemy Session object.
         """
-
         supplemental_metrics = {}
-
         for field_name, value in activity_data.items():
             # Skip dictionaries and lists (complex nested structures).
             if isinstance(value, (dict, list)):
@@ -1010,10 +994,8 @@ class GarminProcessor(Processor):
         :param file_path: Path to the SLEEP JSON file.
         :param session: SQLAlchemy Session object.
         """
-
         # Load and parse the JSON data.
         sleep_data = self._load_json_file(file_path)
-
         # Process main sleep record to database.
         sleep_id = self._process_sleep_base(sleep_data, session)
 
@@ -1044,7 +1026,6 @@ class GarminProcessor(Processor):
         :param session: SQLAlchemy Session object.
         :return: Sleep ID from the processed record, if the record was created.
         """
-
         # Extract dailySleepDTO section.
         daily_sleep_dto = sleep_data.pop("dailySleepDTO", {})
 
@@ -1277,15 +1258,14 @@ class GarminProcessor(Processor):
         Process sleep stage classification intervals from sleepLevels array.
 
         Each interval is a contiguous segment with a single discrete sleep stage (Deep,
-        Light, REM, Awake). Uses INSERT ... ON CONFLICT DO NOTHING on
-        (sleep_id, start_ts), matching the idempotency pattern of the sibling sleep
-        time-series tables.
+        Light, REM, Awake). Uses INSERT ... ON CONFLICT DO NOTHING on (sleep_id,
+        start_ts), matching the idempotency pattern of the sibling sleep time-series
+        tables.
 
         :param sleep_data: Complete JSON sleep data (modified by pop()).
         :param sleep_id: Sleep session ID.
         :param session: SQLAlchemy Session object.
         """
-
         sleep_levels = sleep_data.pop("sleepLevels", [])
         if not sleep_levels:
             LOGGER.warning("⚠️ No sleep level data found.")
@@ -1335,14 +1315,14 @@ class GarminProcessor(Processor):
         self, sleep_data: dict, sleep_id: int, session: Session
     ):
         """
-        Process sleep movement data from sleepMovement array. Uses pop() to remove
-        processed fields from sleep_data dictionary.
+        Process sleep movement data from sleepMovement array.
+
+        Uses pop() to remove processed fields from sleep_data dictionary.
 
         :param sleep_data: Complete JSON sleep data.
         :param sleep_id: Sleep session ID.
         :param session: SQLAlchemy Session object.
         """
-
         sleep_movement = sleep_data.pop("sleepMovement", [])
         if not sleep_movement:
             return
@@ -1377,14 +1357,14 @@ class GarminProcessor(Processor):
         self, sleep_data: dict, sleep_id: int, session: Session
     ):
         """
-        Process sleep restless moments from sleepRestlessMoments array. Uses pop() to
-        remove processed fields from sleep_data dictionary.
+        Process sleep restless moments from sleepRestlessMoments array.
+
+        Uses pop() to remove processed fields from sleep_data dictionary.
 
         :param sleep_data: Complete JSON sleep data.
         :param sleep_id: Sleep session ID.
         :param session: SQLAlchemy Session object.
         """
-
         restless_moments = sleep_data.pop("sleepRestlessMoments", [])
         if not restless_moments:
             return
@@ -1419,14 +1399,14 @@ class GarminProcessor(Processor):
         self, sleep_data: dict, sleep_id: int, session: Session
     ):
         """
-        Process SpO2 data from wellnessEpochSPO2DataDTOList array. Uses pop() to remove
-        processed fields from sleep_data dictionary.
+        Process SpO2 data from wellnessEpochSPO2DataDTOList array.
+
+        Uses pop() to remove processed fields from sleep_data dictionary.
 
         :param sleep_data: Complete JSON sleep data.
         :param sleep_id: Sleep session ID.
         :param session: SQLAlchemy Session object.
         """
-
         spo2_data = sleep_data.pop("wellnessEpochSPO2DataDTOList", [])
         if not spo2_data:
             LOGGER.warning("⚠️ No SpO2 data found.")
@@ -1462,14 +1442,14 @@ class GarminProcessor(Processor):
         self, sleep_data: dict, sleep_id: int, session: Session
     ):
         """
-        Process HRV data from hrvData array. Uses pop() to remove processed fields from
-        sleep_data dictionary.
+        Process HRV data from hrvData array.
+
+        Uses pop() to remove processed fields from sleep_data dictionary.
 
         :param sleep_data: Complete JSON sleep data.
         :param sleep_id: Sleep session ID.
         :param session: SQLAlchemy Session object.
         """
-
         hrv_data = sleep_data.pop("hrvData", [])
         if not hrv_data:
             LOGGER.warning("⚠️ No HRV data found.")
@@ -1503,14 +1483,14 @@ class GarminProcessor(Processor):
         self, sleep_data: dict, sleep_id: int, session: Session
     ):
         """
-        Process breathing disruption data from breathingDisruptionData array. Uses pop()
-        to remove processed fields from sleep_data dictionary.
+        Process breathing disruption data from breathingDisruptionData array.
+
+        Uses pop() to remove processed fields from sleep_data dictionary.
 
         :param sleep_data: Complete JSON sleep data.
         :param sleep_id: Sleep session ID.
         :param session: SQLAlchemy Session object.
         """
-
         breathing_data = sleep_data.pop("breathingDisruptionData", [])
         if not breathing_data:
             LOGGER.warning("⚠️ No breathing disruption data found.")
@@ -1544,16 +1524,15 @@ class GarminProcessor(Processor):
 
     def _process_training_status(self, file_path: Path, session: Session):
         """
-        Process a TRAINING_STATUS file. Extracts VO2 max data, acclimation metrics, and
-        training load information.
+        Process a TRAINING_STATUS file.
+
+        Extracts VO2 max data, acclimation metrics, and training load information.
 
         :param file_path: Path to the TRAINING_STATUS JSON file.
         :param session: SQLAlchemy Session object.
         """
-
         # Load and parse the JSON data.
         training_status_data = self._load_json_file(file_path)
-
         # Extract and process each data type.
         self._process_vo2_max_and_acclimation(training_status_data, session)
         self._process_training_load(training_status_data, session)
@@ -1569,7 +1548,6 @@ class GarminProcessor(Processor):
         :param training_status_data: Complete JSON training status data.
         :param session: SQLAlchemy Session object.
         """
-
         vo2_max_section = training_status_data.pop("mostRecentVO2Max", {})
         if not vo2_max_section:
             LOGGER.warning("⚠️ No VO2 max data found.")
@@ -1677,7 +1655,6 @@ class GarminProcessor(Processor):
         :param training_status_data: Complete JSON training status data.
         :param session: SQLAlchemy Session object.
         """
-
         balance_record = None
 
         # Extract training load balance data.
@@ -1815,7 +1792,6 @@ class GarminProcessor(Processor):
         :param file_path: Path to the TRAINING_READINESS JSON file.
         :param session: SQLAlchemy Session object.
         """
-
         # Load and parse the JSON data.
         training_readiness_list = self._load_json_file(file_path)
 
@@ -1880,7 +1856,6 @@ class GarminProcessor(Processor):
         :param file_path: Path to the STRESS JSON file.
         :param session: SQLAlchemy Session object.
         """
-
         # Load and parse the JSON data.
         stress_data = self._load_json_file(file_path)
 
@@ -1957,7 +1932,6 @@ class GarminProcessor(Processor):
         :param file_path: Path to the HEART_RATE JSON file.
         :param session: SQLAlchemy Session object.
         """
-
         # Load and parse the JSON data.
         heart_rate_data = self._load_json_file(file_path)
 
@@ -2002,7 +1976,6 @@ class GarminProcessor(Processor):
         :param file_path: Path to the STEPS JSON file.
         :param session: SQLAlchemy Session object.
         """
-
         # Load and parse the JSON data.
         steps_data = self._load_json_file(file_path)
 
@@ -2049,13 +2022,11 @@ class GarminProcessor(Processor):
         :param file_path: Path to the RESPIRATION JSON file.
         :param session: SQLAlchemy Session object.
         """
-
         # Load and parse the JSON data.
         respiration_data = self._load_json_file(file_path)
 
         # Extract respiration timeseries data.
         respiration_values = respiration_data.pop("respirationValuesArray", [])
-
         # Process respiration measurements.
         respiration_records = []
         for respiration_value in respiration_values if respiration_values else []:
@@ -2100,13 +2071,11 @@ class GarminProcessor(Processor):
         :param file_path: Path to the INTENSITY_MINUTES JSON file.
         :param session: SQLAlchemy Session object.
         """
-
         # Load and parse the JSON data.
         intensity_data = self._load_json_file(file_path)
 
         # Extract intensity minutes timeseries data.
         intensity_values = intensity_data.pop("imValuesArray", [])
-
         # Process intensity minute measurements.
         intensity_records = []
         for intensity_value in intensity_values if intensity_values else []:
@@ -2199,13 +2168,11 @@ class GarminProcessor(Processor):
         :param file_path: Path to the FLOORS JSON file.
         :param session: SQLAlchemy Session object.
         """
-
         # Load and parse the JSON data.
         floors_data = self._load_json_file(file_path)
 
         # Extract floors timeseries data.
         floor_values = floors_data.pop("floorValuesArray", [])
-
         # Process floors measurements.
         floors_records = []
         for floor_value in floor_values if floor_values else []:
@@ -2250,7 +2217,6 @@ class GarminProcessor(Processor):
         :param file_path: Path to the PERSONAL_RECORDS JSON file.
         :param session: SQLAlchemy Session object.
         """
-
         # Load and parse the JSON data.
         personal_records_data = self._load_json_file(file_path)
 
@@ -2258,7 +2224,6 @@ class GarminProcessor(Processor):
         all_latest_prs = []
         personal_records = []
         skipped_records_count = 0
-
         for record in personal_records_data if personal_records_data else []:
             type_id = record.pop("typeId")
             activity_id = record.pop("activityId")
@@ -2381,14 +2346,12 @@ class GarminProcessor(Processor):
         :param file_path: Path to the RACE_PREDICTIONS JSON file.
         :param session: SQLAlchemy Session object.
         """
-
         # Load and parse the JSON data.
         race_prediction_data = self._load_json_file(file_path)
 
         if not race_prediction_data:
             LOGGER.warning("⚠️ No race predictions data found.")
             return
-
         # Find all race predictions with `latest`=True for this user.
         latest_race_predictions = (
             session.execute(
@@ -2446,7 +2409,6 @@ class GarminProcessor(Processor):
         :param file_path: Path to the FIT file.
         :param session: SQLAlchemy Session object.
         """
-
         # Extract `activity_id` from filename.
         # FIT files have format: {user_id}_ACTIVITY_{activity_id}_{timestamp}.fit
         # Use regex to extract activity_id directly from filename.

--- a/dags/pipelines/garmin/sqla_models.py
+++ b/dags/pipelines/garmin/sqla_models.py
@@ -53,9 +53,9 @@ class UserProfile(InsertBase):
     """
     User fitness profile data from Garmin Connect.
 
-    Contains physical characteristics and fitness metrics. The latest column
-    indicates the most recent profile record for each user. Multiple records
-    can exist per `user_id`, but only one can have `latest`=True.
+    Contains physical characteristics and fitness metrics. The latest column indicates
+    the most recent profile record for each user. Multiple records can exist per
+    `user_id`, but only one can have `latest`=True.
     """
 
     __tablename__ = "user_profile"
@@ -912,12 +912,12 @@ class ActivityPath(InsertBase):
     """
     Eagerly materialized GPS path for activities.
 
-    Stores a deck.gl-compatible coordinate array built from per-timestamp GPS samples
-    in `ActivityTsMetric` during FIT file processing. One row per activity that has
-    GPS data; activities without GPS samples (indoor workouts, etc.) have no row.
-    Uses delete+insert in `_process_fit_file` for reprocessing idempotency. Stored
-    as JSONB; Superset's virtual dataset casts to text so the legacy DeckPathViz
-    path layer receives a JSON string.
+    Stores a deck.gl-compatible coordinate array built from per-timestamp GPS samples in
+    `ActivityTsMetric` during FIT file processing. One row per activity that has GPS
+    data; activities without GPS samples (indoor workouts, etc.) have no row. Uses
+    delete+insert in `_process_fit_file` for reprocessing idempotency. Stored as JSONB;
+    Superset's virtual dataset casts to text so the legacy DeckPathViz path layer
+    receives a JSON string.
     """
 
     __tablename__ = "activity_path"

--- a/dags/pipelines/garmin/utility_scripts/backfill_sleep_level.py
+++ b/dags/pipelines/garmin/utility_scripts/backfill_sleep_level.py
@@ -53,7 +53,6 @@ def _parse_sleep_file(
     :return: Tuple of (user_id, calendar_date, sleep_levels) if parseable, otherwise
         None.
     """
-
     match = SLEEP_FILENAME_RE.match(file_path.name)
     if not match:
         LOGGER.warning(f"⚠️ Skipping {file_path.name}: invalid filename pattern.")
@@ -82,7 +81,6 @@ def _build_sleep_level_records(sleep_id: int, sleep_levels: list) -> list:
     :param sleep_levels: Raw sleepLevels list from the JSON file.
     :return: List of SleepLevel instances ready to be persisted.
     """
-
     records = []
     for level in sleep_levels:
         start_gmt_str = level.get("startGMT")
@@ -124,7 +122,6 @@ def backfill_sleep_level(store_dir: Path) -> None:
 
     :param store_dir: Garmin store directory containing SLEEP JSON files.
     """
-
     sleep_files = sorted(store_dir.rglob("*_SLEEP_*.json"))
     LOGGER.info(f"🔍 Found {len(sleep_files)} SLEEP files under {store_dir}.")
 
@@ -209,7 +206,6 @@ def main() -> None:
     """
     Parse CLI arguments and run the sleep_level backfill.
     """
-
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--store-dir",

--- a/dags/pipelines/garmin/utility_scripts/refresh_garmin_tokens.py
+++ b/dags/pipelines/garmin/utility_scripts/refresh_garmin_tokens.py
@@ -117,7 +117,6 @@ def _validate_input(value: str, field_name: str) -> str:
     :param field_name: Name of the field for error messages.
     :return: Validated input value.
     """
-
     if not value:
         raise ValueError(f"❌ {field_name} is required.")
     return value
@@ -127,7 +126,6 @@ def _print_troubleshooting() -> None:
     """
     Print common troubleshooting steps.
     """
-
     logger.info(
         "\n🔍 Troubleshooting:"
         "\n   - Verify your email and password are correct."
@@ -145,7 +143,6 @@ def get_credentials() -> Tuple[str, str]:
 
     :return: Tuple of (email, password).
     """
-
     logger.info(f"🔐 Garmin Connect Token Refresh Utility.\n{'=' * 50}")
 
     # Try environment variables first.
@@ -172,7 +169,6 @@ def get_mfa_code() -> str:
 
     :return: MFA code string.
     """
-
     logger.info(
         "\n🔢 Multi-Factor Authentication Required."
         "\n   Check your email or phone for the MFA code."
@@ -193,7 +189,6 @@ def _handle_mfa_authentication(client: GarminClient, result2) -> None:
     :param client: GarminClient instance.
     :param result2: MFA continuation token from login result.
     """
-
     logger.info("✅ Initial authentication successful.")
 
     for attempt in range(2):  # Allow 2 attempts (0 and 1)
@@ -223,16 +218,15 @@ def refresh_tokens(email: str, password: str, base_token_dir: str = "~/.garminco
     """
     Refresh Garmin Connect tokens with MFA support.
 
-    After successful authentication, the Garmin user ID is auto-detected via the
-    user profile API. Tokens are saved to a user-specific subdirectory:
+    After successful authentication, the Garmin user ID is auto-detected via the user
+    profile API. Tokens are saved to a user-specific subdirectory:
     ``<base_token_dir>/<user_id>/``.
 
     :param email: Garmin Connect email.
     :param password: Garmin Connect password.
-    :param base_token_dir: Base directory for token storage. Tokens will be saved
-        to a ``<user_id>`` subdirectory within this directory.
+    :param base_token_dir: Base directory for token storage. Tokens will be saved to a
+        ``<user_id>`` subdirectory within this directory.
     """
-
     base_path = Path(base_token_dir).expanduser()
 
     logger.info(
@@ -303,7 +297,6 @@ def main() -> None:
     """
     Main function to orchestrate token refresh process.
     """
-
     # Get credentials.
     email, password = get_credentials()
 

--- a/dags/pipelines/linkedin/process.py
+++ b/dags/pipelines/linkedin/process.py
@@ -42,7 +42,6 @@ class LinkedInProcessor(Processor):
         :param file_set: FileSet containing LinkedIn CSV files to process.
         :param session: SQLAlchemy Session object.
         """
-
         for file_path in file_set.file_paths:
             LOGGER.info(f"Processing LinkedIn connections file: {file_path.name}.")
             self._process_connections_file(file_path, session)
@@ -61,7 +60,6 @@ class LinkedInProcessor(Processor):
         :param file_path: Path to the Connections CSV file.
         :param session: SQLAlchemy Session object.
         """
-
         # Extract capture date from filename (e.g., "Connections_20260110.csv").
         capture_date = self._extract_capture_date(file_path)
         if not capture_date:
@@ -149,7 +147,6 @@ class LinkedInProcessor(Processor):
         :param file_path: Path to the CSV file.
         :return: List of dictionaries containing connection data.
         """
-
         connections = []
 
         with open(file_path, "r", encoding="utf-8") as f:
@@ -183,7 +180,6 @@ class LinkedInProcessor(Processor):
         :param date_str: Date string in LinkedIn format.
         :return: date object or None if parsing fails.
         """
-
         if not date_str or not date_str.strip():
             return None
 
@@ -204,7 +200,6 @@ class LinkedInProcessor(Processor):
         :param file_path: Path to the CSV file.
         :return: date object or None if extraction fails.
         """
-
         # Match pattern like "20260110" in filename.
         match = re.search(r"(\d{8})", file_path.name)
         if not match:
@@ -231,7 +226,6 @@ class LinkedInProcessor(Processor):
         :param active_urls: Set of URLs present in the current CSV file.
         :param capture_date: Capture date of the current file being processed.
         """
-
         # Query URLs of active connections with capture_date <= current file's date.
         db_active_urls = set(
             session.execute(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ skip_covered = true
 add-blank-after-docstring = true
 black = true
 close-quotes-on-newline = true
+exclude = [".venv", "venv", ".git", "build", "dist"]
 in-place = true
 make-summary-multi-line = true
 pre-summary-newline = true

--- a/tests/dags/lib/conftest.py
+++ b/tests/dags/lib/conftest.py
@@ -26,7 +26,6 @@ def get_postgres_password() -> str:
 
     :return: The password value, or 'postgres' if not found.
     """
-
     sql_credentials_dir = os.getenv("SQL_CREDENTIALS_DIR")
     if not sql_credentials_dir:
         # Return default for test environments without credentials configured.
@@ -87,7 +86,6 @@ class MyTest(Base):
         """
         Compare two MyTest instances for equality.
         """
-
         return (
             self.id == other.id
             and self.col_a == other.col_a
@@ -100,14 +98,12 @@ class MyTest(Base):
         """
         Compare two MyTest instances for sorting by id.
         """
-
         return self.id < other.id
 
     def __repr__(self) -> str:
         """
         String representation of MyTest instance.
         """
-
         return (
             f"<MyTest(id={self.id}, col_a={self.col_a}, col_b={self.col_b}, "
             f"col_c={self.col_c}, latest={self.latest})>"
@@ -121,7 +117,6 @@ def db_engine() -> Generator[Engine, None, None]:
 
     :return: The SQLAlchemy engine instance.
     """
-
     engine = create_engine(TEST_DB_URL)
     MyTest.metadata.create_all(engine)
     yield engine
@@ -136,7 +131,6 @@ def db_session(db_engine: Engine) -> Generator[Session, None, None]:
     :param db_engine: The SQLAlchemy engine instance.
     :return: The SQLAlchemy session instance.
     """
-
     session = Session(db_engine)
     yield session
     session.close()
@@ -149,7 +143,6 @@ def etl_result_engine() -> Generator[Engine, None, None]:
 
     :return: The SQLAlchemy engine instance for reporting.
     """
-
     engine = create_engine(TEST_DB_URL)
     with engine.begin() as conn:
         # Drop schema if exists.
@@ -170,7 +163,6 @@ def etl_result_session(etl_result_engine: Engine) -> Generator[Session, None, No
     :param reporting_engine: The SQLAlchemy engine instance for reporting.
     :return: The SQLAlchemy session instance for reporting.
     """
-
     session = Session(etl_result_engine)
     yield session
     session.close()

--- a/tests/dags/lib/test_dag_utils.py
+++ b/tests/dags/lib/test_dag_utils.py
@@ -186,7 +186,6 @@ def make_config(
     Create a DummyConfig with specified file types, files, max tasks, and min batch
     size.
     """
-
     config = DummyConfig()
     config.file_types = file_types
     config.max_process_tasks = max_tasks
@@ -294,7 +293,6 @@ class TestBatch:
         """
         Test that batch data can be serialized and deserialized correctly.
         """
-
         file1 = DummyFile("2025-08-02T12:00:00+00:00_data1.csv")
         file2 = DummyFile("2025-08-02T12:00:00+00:00_data2.csv")
         file3 = DummyFile("2025-08-02T12:00:00+00:00_meta.json")
@@ -478,7 +476,6 @@ class TestFileSetSerialization:
         """
         Test FileSet to_serializable method.
         """
-
         from dags.lib.filesystem_utils import FileSet
         from pathlib import Path
 
@@ -504,7 +501,6 @@ class TestFileSetSerialization:
         """
         Test FileSet from_serializable method.
         """
-
         from dags.lib.filesystem_utils import FileSet
         from pathlib import Path
 

--- a/tests/dags/lib/test_etl_monitor_utils.py
+++ b/tests/dags/lib/test_etl_monitor_utils.py
@@ -25,7 +25,6 @@ def dummy_etl_result() -> ETLResult:
     """
     Fixture to create a basic ETLResult object.
     """
-
     config = DummyConfig()
     dag_start_date = datetime(2025, 8, 1, 12, 0, 0)
     dag_run_id = "run_123"
@@ -38,7 +37,6 @@ def test_etl_result_record_fields() -> None:
     """
     Test ETLResultRecord field assignment.
     """
-
     record = ETLResultRecord(
         file_name="file.csv",
         success=True,
@@ -55,7 +53,6 @@ def test_set_result_record(dummy_etl_result: ETLResult) -> None:
     """
     Test setting a result record in ETLResult.
     """
-
     etl_result = dummy_etl_result
     etl_result.set_result_record("file.csv", True)
     assert "file.csv" in etl_result.result_records
@@ -66,7 +63,6 @@ def test_successes_and_errors(dummy_etl_result: ETLResult) -> None:
     """
     Test successes and errors properties of ETLResult.
     """
-
     etl_result = dummy_etl_result
     etl_result.set_result_record("file1.csv", True)
     etl_result.set_result_record(
@@ -92,7 +88,6 @@ def test_etl_result_equality(
     """
     Test ETLResult equality comparison.
     """
-
     etl_result1 = dummy_etl_result
     etl_result2 = ETLResult(
         etl_result1.config,
@@ -112,7 +107,6 @@ def test_submit_writes_to_database(
     """
     Test that submit() writes ETL results to the database.
     """
-
     from dags.lib.etl_monitor_utils import ETLResultSqla
 
     config = DummyConfig()

--- a/tests/dags/lib/test_sql_utils.py
+++ b/tests/dags/lib/test_sql_utils.py
@@ -17,7 +17,6 @@ def test_make_base_with_update_ts_and_schema():
     """
     Test that make_base creates correct columns and schema.
     """
-
     Base = make_base(schema="test_schema", include_update_ts=True)
 
     class TestModel(Base):
@@ -40,7 +39,6 @@ class TestUpsertModelInstances:
         """
         Add a row with id=1 and col_a="A" to the session and flush.
         """
-
         obj = MyTest(id=1, col_a="A")
         session.add(obj)
         session.flush()
@@ -50,7 +48,6 @@ class TestUpsertModelInstances:
         """
         Test upsert_model_instances for insert and update behavior.
         """
-
         obj1 = MyTest(id=1, col_a="A")
         obj2 = MyTest(id=2, col_a="B")
         kwargs = {
@@ -89,7 +86,6 @@ class TestUpsertModelInstances:
         """
         Test upsert_model_instances with returning_columns against real DB.
         """
-
         obj = MyTest(id=1, col_a="A", col_b="B")
         result = upsert_model_instances(
             db_session,
@@ -107,7 +103,6 @@ class TestUpsertModelInstances:
         """
         Test upsert_model_instances without returning_columns returns None.
         """
-
         obj = MyTest(id=1, col_a="A")
         result = upsert_model_instances(
             db_session,
@@ -125,7 +120,6 @@ class TestUpsertModelInstances:
         """
         Test that _upsert_values raises ValueError if conflict_columns is missing.
         """
-
         with pytest.raises(ValueError):
             _upsert_values(
                 MyTest,
@@ -138,7 +132,6 @@ class TestUpsertModelInstances:
         """
         Test _upsert_values UPSERT mode updates on conflict.
         """
-
         # Insert initial row.
         kwargs = {
             "conflict_columns": ["id"],
@@ -165,7 +158,6 @@ class TestUpsertModelInstances:
         """
         Test _upsert_values INSERT_IGNORE mode does not update on conflict.
         """
-
         # Insert initial row.
         _upsert_values(
             MyTest,
@@ -196,7 +188,6 @@ class TestUpsertModelInstances:
         """
         Test _upsert_values INSERT mode inserts new rows.
         """
-
         # Insert first row.
         kwargs = {
             "conflict_columns": None,
@@ -227,7 +218,6 @@ class TestUpsertModelInstances:
         """
         Test that rollback undoes inserted rows.
         """
-
         # Insert two rows.
         kwargs = {
             "conflict_columns": None,
@@ -250,16 +240,16 @@ class TestUpsertModelInstances:
         Test that _upsert_values automatically sets update_ts when model has this
         column.
         """
-
         # Use raw SQL to test the functionality directly without table creation.
-        db_session.execute(text("""
-            CREATE TEMP TABLE test_update_ts_temp (
-                id INTEGER PRIMARY KEY,
-                name TEXT,
-                create_ts TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-                update_ts TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        db_session.execute(
+            text(
+                "CREATE TEMP TABLE test_update_ts_temp ("
+                " id INTEGER PRIMARY KEY,"
+                " name TEXT,"
+                " create_ts TIMESTAMPTZ NOT NULL DEFAULT NOW(),"
+                " update_ts TIMESTAMPTZ NOT NULL DEFAULT NOW())"
             )
-        """))
+        )
 
         # Create a simple mock model for this test.
         class TempBase(DeclarativeBase):
@@ -321,7 +311,6 @@ class TestUpsertModelInstances:
         """
         Test that models without update_ts column continue to work unchanged.
         """
-
         # This should work exactly as before - using MyTest which has no update_ts.
         _upsert_values(
             MyTest,
@@ -343,16 +332,16 @@ class TestUpsertModelInstances:
         """
         Test that explicit update_ts values in update_columns are preserved.
         """
-
         # Use raw SQL to test the functionality directly.
-        db_session.execute(text("""
-            CREATE TEMP TABLE test_explicit_ts_temp (
-                id INTEGER PRIMARY KEY,
-                name TEXT,
-                create_ts TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-                update_ts TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        db_session.execute(
+            text(
+                "CREATE TEMP TABLE test_explicit_ts_temp ("
+                " id INTEGER PRIMARY KEY,"
+                " name TEXT,"
+                " create_ts TIMESTAMPTZ NOT NULL DEFAULT NOW(),"
+                " update_ts TIMESTAMPTZ NOT NULL DEFAULT NOW())"
             )
-        """))
+        )
 
         # Create a simple mock model for this test.
         class TempBase(DeclarativeBase):
@@ -408,15 +397,15 @@ class TestUpsertModelInstances:
         """
         Test latest_check_column with strict > comparison (default behavior).
         """
-
         # Create temp table with version column.
-        db_session.execute(text("""
-            CREATE TEMP TABLE test_version_strict_temp (
-                id INTEGER PRIMARY KEY,
-                name TEXT,
-                version INTEGER NOT NULL
+        db_session.execute(
+            text(
+                "CREATE TEMP TABLE test_version_strict_temp ("
+                " id INTEGER PRIMARY KEY,"
+                " name TEXT,"
+                " version INTEGER NOT NULL)"
             )
-        """))
+        )
 
         class TempBase(DeclarativeBase):
             pass
@@ -495,15 +484,15 @@ class TestUpsertModelInstances:
         """
         Test latest_check_column with >= comparison (inclusive).
         """
-
         # Create temp table with version column.
-        db_session.execute(text("""
-            CREATE TEMP TABLE test_version_inclusive_temp (
-                id INTEGER PRIMARY KEY,
-                name TEXT,
-                version INTEGER NOT NULL
+        db_session.execute(
+            text(
+                "CREATE TEMP TABLE test_version_inclusive_temp ("
+                " id INTEGER PRIMARY KEY,"
+                " name TEXT,"
+                " version INTEGER NOT NULL)"
             )
-        """))
+        )
 
         class TempBase(DeclarativeBase):
             pass
@@ -572,19 +561,19 @@ class TestUpsertModelInstances:
         """
         Test that update_ts is updated when latest_check_column condition passes.
         """
-
         import time
 
         # Create temp table with version and update_ts columns.
-        db_session.execute(text("""
-            CREATE TEMP TABLE test_version_update_ts_temp (
-                id INTEGER PRIMARY KEY,
-                name TEXT,
-                version INTEGER NOT NULL,
-                create_ts TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-                update_ts TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        db_session.execute(
+            text(
+                "CREATE TEMP TABLE test_version_update_ts_temp ("
+                " id INTEGER PRIMARY KEY,"
+                " name TEXT,"
+                " version INTEGER NOT NULL,"
+                " create_ts TIMESTAMPTZ NOT NULL DEFAULT NOW(),"
+                " update_ts TIMESTAMPTZ NOT NULL DEFAULT NOW())"
             )
-        """))
+        )
 
         class TempBase(DeclarativeBase):
             pass
@@ -661,7 +650,6 @@ class TestChunkedUpsert:
         """
         Test that all rows are inserted when split across chunks.
         """
-
         values = [{"id": i, "col_a": f"val_{i}"} for i in range(1, 6)]
         _upsert_values(
             model=MyTest,
@@ -678,7 +666,6 @@ class TestChunkedUpsert:
         """
         Test that RETURNING results are collected from every chunk.
         """
-
         values = [{"id": i, "col_a": f"val_{i}"} for i in range(1, 6)]
         results = _upsert_values(
             model=MyTest,
@@ -698,7 +685,6 @@ class TestChunkedUpsert:
         """
         Test that chunked upsert updates existing rows correctly.
         """
-
         # Seed rows.
         seed = [{"id": i, "col_a": f"old_{i}"} for i in range(1, 6)]
         _upsert_values(
@@ -726,7 +712,6 @@ class TestChunkedUpsert:
         """
         Test INSERT_IGNORE with RETURNING re-queries per chunk.
         """
-
         # Seed a subset of rows.
         seed = [{"id": 1, "col_a": "A"}, {"id": 3, "col_a": "C"}]
         _upsert_values(
@@ -763,7 +748,6 @@ class TestChunkedUpsert:
         """
         Test plain INSERT (no conflict) works across chunks.
         """
-
         values = [{"id": i, "col_a": f"val_{i}"} for i in range(1, 6)]
         _upsert_values(
             model=MyTest,

--- a/tests/dags/pipelines/garmin/garmin_client/test_api.py
+++ b/tests/dags/pipelines/garmin/garmin_client/test_api.py
@@ -1,10 +1,9 @@
 """
 Unit tests for dags.pipelines.garmin.garmin_client.api module.
 
-Verifies the URL patterns, query parameters, and pagination behavior of the 15
-API method wrappers used by the openetl pipeline. Each test mocks
-``client._connectapi`` (or ``_download``) and asserts the correct URL/params
-were passed.
+Verifies the URL patterns, query parameters, and pagination behavior of the 15 API
+method wrappers used by the openetl pipeline. Each test mocks ``client._connectapi`` (or
+``_download``) and asserts the correct URL/params were passed.
 """
 
 from unittest.mock import MagicMock
@@ -25,7 +24,6 @@ def mock_client() -> MagicMock:
 
     :return: MagicMock standing in for a GarminClient instance.
     """
-
     client = MagicMock()
     client.display_name = "stub_user"
     return client
@@ -45,21 +43,18 @@ class TestValidateDateFormat:
         """
         A YYYY-MM-DD string passes through unchanged.
         """
-
         assert _validate_date_format("2026-04-07") == "2026-04-07"
 
     def test_strips_whitespace(self) -> None:
         """
         Surrounding whitespace is stripped.
         """
-
         assert _validate_date_format("  2026-04-07  ") == "2026-04-07"
 
     def test_rejects_wrong_shape(self) -> None:
         """
         Strings that don't match YYYY-MM-DD raise ValueError.
         """
-
         with pytest.raises(ValueError):
             _validate_date_format("04/07/2026")
 
@@ -67,7 +62,6 @@ class TestValidateDateFormat:
         """
         Strings with the right shape but an invalid date raise ValueError.
         """
-
         with pytest.raises(ValueError):
             _validate_date_format("2026-02-30")
 
@@ -75,7 +69,6 @@ class TestValidateDateFormat:
         """
         Non-string inputs raise ValueError.
         """
-
         with pytest.raises(ValueError):
             _validate_date_format(20260407)  # type: ignore[arg-type]
 
@@ -95,7 +88,6 @@ class TestGetSleepData:
         Sleep URL contains the display name and the request includes the
         ``nonSleepBufferMinutes=60`` query param.
         """
-
         # Arrange.
         mock_client._connectapi.return_value = {"sleep": "data"}
 
@@ -119,7 +111,6 @@ class TestGetStressData:
         """
         Stress URL embeds the date in the path (no display_name).
         """
-
         # Arrange.
         mock_client._connectapi.return_value = {"stress": "data"}
 
@@ -141,7 +132,6 @@ class TestGetRespirationData:
         """
         Respiration URL embeds the date in the path.
         """
-
         # Arrange.
         mock_client._connectapi.return_value = {"resp": "data"}
 
@@ -163,7 +153,6 @@ class TestGetHeartRates:
         """
         Heart rate URL contains display_name and a ``date`` query param.
         """
-
         # Arrange.
         mock_client._connectapi.return_value = {"hr": "data"}
 
@@ -186,7 +175,6 @@ class TestGetTrainingReadiness:
         """
         Training readiness URL embeds the date in the path.
         """
-
         # Arrange.
         mock_client._connectapi.return_value = [{"score": 80}]
 
@@ -207,7 +195,6 @@ class TestGetTrainingStatus:
         """
         Training status URL embeds the date in the path.
         """
-
         # Arrange.
         mock_client._connectapi.return_value = {"status": "productive"}
 
@@ -228,7 +215,6 @@ class TestGetStepsData:
         """
         Steps URL contains display_name and a ``date`` query param.
         """
-
         # Arrange.
         mock_client._connectapi.return_value = [{"steps": 100}]
 
@@ -248,10 +234,8 @@ class TestGetStepsData:
         """
         A None response is normalized to an empty list.
         """
-
         # Arrange.
         mock_client._connectapi.return_value = None
-
         # Act.
         result = api.get_steps_data(mock_client, "2026-04-07")
 
@@ -268,10 +252,8 @@ class TestGetFloors:
         """
         Floors URL embeds the date in the path.
         """
-
         # Act.
         api.get_floors(mock_client, "2026-04-07")
-
         # Assert.
         url = mock_client._connectapi.call_args[0][0]
         assert url == "/wellness-service/wellness/floorsChartData/daily/2026-04-07"
@@ -286,10 +268,8 @@ class TestGetIntensityMinutesData:
         """
         Intensity minutes URL embeds the date in the path.
         """
-
         # Act.
         api.get_intensity_minutes_data(mock_client, "2026-04-07")
-
         # Assert.
         url = mock_client._connectapi.call_args[0][0]
         assert url == "/wellness-service/wellness/daily/im/2026-04-07"
@@ -309,7 +289,6 @@ class TestGetActivitiesByDate:
         """
         The loop fetches 20-activity pages until the API returns [].
         """
-
         # Arrange. First page has 2 activities, second page is empty.
         mock_client._connectapi.side_effect = [
             [{"id": 1}, {"id": 2}],
@@ -332,10 +311,8 @@ class TestGetActivitiesByDate:
         """
         Optional ``enddate``, ``activitytype``, and ``sortorder`` propagate.
         """
-
         # Arrange.
         mock_client._connectapi.return_value = []
-
         # Act.
         api.get_activities_by_date(
             mock_client,
@@ -357,7 +334,6 @@ class TestGetActivitiesByDate:
         """
         A bad start date raises ValueError before any API call.
         """
-
         with pytest.raises(ValueError):
             api.get_activities_by_date(mock_client, "04/01/2026")
         mock_client._connectapi.assert_not_called()
@@ -372,10 +348,8 @@ class TestGetActivityExerciseSets:
         """
         Exercise sets URL contains the activity ID.
         """
-
         # Arrange.
         mock_client._connectapi.return_value = {"sets": []}
-
         # Act.
         api.get_activity_exercise_sets(mock_client, 12345)
 
@@ -387,7 +361,6 @@ class TestGetActivityExerciseSets:
         """
         Activity IDs must be positive integers.
         """
-
         with pytest.raises(ValueError):
             api.get_activity_exercise_sets(mock_client, 0)
 
@@ -406,7 +379,6 @@ class TestGetPersonalRecord:
         """
         Personal record URL ends in the display name.
         """
-
         # Act.
         api.get_personal_record(mock_client)
 
@@ -425,7 +397,6 @@ class TestGetRacePredictions:
         The openetl hot path calls ``get_race_predictions()`` with no args and expects
         the ``/latest/<display_name>`` endpoint.
         """
-
         # Act.
         api.get_race_predictions(mock_client)
 
@@ -438,10 +409,8 @@ class TestGetRacePredictions:
         Providing all three args produces ``/<type>/<display_name>`` plus the date range
         params.
         """
-
         # Act.
         api.get_race_predictions(mock_client, "2026-01-01", "2026-04-01", _type="daily")
-
         # Assert.
         url = mock_client._connectapi.call_args[0][0]
         params = mock_client._connectapi.call_args[1]["params"]
@@ -455,7 +424,6 @@ class TestGetRacePredictions:
         """
         Unknown ``_type`` values raise ValueError.
         """
-
         with pytest.raises(ValueError):
             api.get_race_predictions(
                 mock_client, "2026-01-01", "2026-04-01", _type="weekly"
@@ -465,7 +433,6 @@ class TestGetRacePredictions:
         """
         Providing some but not all of the three args raises ValueError.
         """
-
         with pytest.raises(ValueError):
             api.get_race_predictions(mock_client, "2026-01-01")
 
@@ -473,7 +440,6 @@ class TestGetRacePredictions:
         """
         A start-to-end range over one year raises ValueError.
         """
-
         with pytest.raises(ValueError):
             api.get_race_predictions(
                 mock_client, "2024-01-01", "2026-01-01", _type="daily"
@@ -490,7 +456,6 @@ class TestGetUserProfile:
         ``get_user_profile`` hits ``/user-settings``, NOT the ``/profile`` endpoint that
         ``_load_profile`` uses.
         """
-
         # Arrange.
         mock_client._connectapi.return_value = {"id": "12345678"}
 
@@ -517,13 +482,11 @@ class TestDownloadActivity:
         """
         ``ORIGINAL`` format hits the FIT download URL by default.
         """
-
         # Arrange.
         mock_client._download.return_value = b"FIT_BYTES"
 
         # Act.
         result = api.download_activity(mock_client, 99999)
-
         # Assert.
         assert result == b"FIT_BYTES"
         url = mock_client._download.call_args[0][0]
@@ -533,7 +496,6 @@ class TestDownloadActivity:
         """
         TCX format hits the TCX export URL.
         """
-
         # Act.
         api.download_activity(mock_client, 99999, ActivityDownloadFormat.TCX)
 
@@ -545,7 +507,6 @@ class TestDownloadActivity:
         """
         GPX format hits the GPX export URL.
         """
-
         # Act.
         api.download_activity(mock_client, 99999, ActivityDownloadFormat.GPX)
 

--- a/tests/dags/pipelines/garmin/garmin_client/test_client.py
+++ b/tests/dags/pipelines/garmin/garmin_client/test_client.py
@@ -1,9 +1,9 @@
 """
 Unit tests for dags.pipelines.garmin.garmin_client.client module.
 
-Covers the GarminClient class itself: authentication state, JWT parsing, token
-expiry detection, the DI OAuth2 token exchange and refresh, and the
-authenticated request helper that maps HTTP error codes to typed exceptions.
+Covers the GarminClient class itself: authentication state, JWT parsing, token expiry
+detection, the DI OAuth2 token exchange and refresh, and the authenticated request
+helper that maps HTTP error codes to typed exceptions.
 """
 
 import base64
@@ -34,7 +34,6 @@ def _make_jwt(payload: dict) -> str:
     :param payload: Dictionary to encode as the JWT payload.
     :return: A JWT-shaped string.
     """
-
     header = base64.urlsafe_b64encode(b'{"alg":"none"}').rstrip(b"=").decode()
     body = base64.urlsafe_b64encode(json.dumps(payload).encode()).rstrip(b"=").decode()
     return f"{header}.{body}.sig"
@@ -49,7 +48,6 @@ class TestInit:
         """
         A fresh client has no token, no profile, and is not authenticated.
         """
-
         # Act.
         client = GarminClient()
 
@@ -66,7 +64,6 @@ class TestInit:
         """
         The ``domain`` kwarg propagates to all three URL bases.
         """
-
         # Act.
         client = GarminClient(domain="garmin.cn")
 
@@ -85,7 +82,6 @@ class TestApiHeaders:
         """
         An unauthenticated client cannot build API headers.
         """
-
         # Arrange.
         client = GarminClient()
 
@@ -97,7 +93,6 @@ class TestApiHeaders:
         """
         When a token is held, headers carry the Bearer token.
         """
-
         # Arrange.
         client = GarminClient()
         client.di_token = "stub_access_token"
@@ -119,7 +114,6 @@ class TestExtractClientIdFromJwt:
         """
         A well-formed JWT yields its ``client_id`` claim.
         """
-
         # Arrange.
         token = _make_jwt({"client_id": "GARMIN_TEST_CID", "exp": 9999999999})
 
@@ -133,7 +127,6 @@ class TestExtractClientIdFromJwt:
         """
         A malformed token (no dots) returns None rather than raising.
         """
-
         # Act.
         result = GarminClient._extract_client_id_from_jwt("notajwt")
 
@@ -144,7 +137,6 @@ class TestExtractClientIdFromJwt:
         """
         A JWT without ``client_id`` returns None.
         """
-
         # Arrange.
         token = _make_jwt({"exp": 1234567890})
 
@@ -164,7 +156,6 @@ class TestTokenExpiresSoon:
         """
         A token whose ``exp`` is in the past expires "soon".
         """
-
         # Arrange.
         client = GarminClient()
         client.di_token = _make_jwt({"exp": int(time.time()) - 100})
@@ -176,7 +167,6 @@ class TestTokenExpiresSoon:
         """
         A token expiring within the 15-min refresh window is flagged.
         """
-
         # Arrange.
         client = GarminClient()
         client.di_token = _make_jwt({"exp": int(time.time()) + 60})
@@ -188,7 +178,6 @@ class TestTokenExpiresSoon:
         """
         A token with an ``exp`` 24h in the future does not need refresh.
         """
-
         # Arrange.
         client = GarminClient()
         client.di_token = _make_jwt({"exp": int(time.time()) + 86400})
@@ -200,10 +189,8 @@ class TestTokenExpiresSoon:
         """
         Without a token there is nothing to refresh.
         """
-
         # Arrange.
         client = GarminClient()
-
         # Act & Assert.
         assert client._token_expires_soon() is False
 
@@ -217,7 +204,6 @@ class TestExchangeServiceTicket:
         """
         The first DI client ID succeeds and populates all three fields.
         """
-
         # Arrange.
         client = GarminClient()
         token = _make_jwt({"client_id": "FIRST_CID", "exp": 9999999999})
@@ -248,7 +234,6 @@ class TestExchangeServiceTicket:
 
         We verify by responding "not ok" twice and OK on the third call.
         """
-
         # Arrange.
         client = GarminClient()
         token = _make_jwt({"client_id": "THIRD_CID", "exp": 9999999999})
@@ -282,7 +267,6 @@ class TestExchangeServiceTicket:
         """
         If every client ID is rejected, the exchange raises auth error.
         """
-
         # Arrange.
         client = GarminClient()
         bad_response = MagicMock()
@@ -299,7 +283,6 @@ class TestExchangeServiceTicket:
         """
         A 429 from the DI exchange surfaces as the typed rate-limit error.
         """
-
         # Arrange.
         client = GarminClient()
         rate_limited = MagicMock()
@@ -318,7 +301,6 @@ class TestExchangeServiceTicket:
         typed ``GarminConnectionError`` rather than leaking the underlying
         requests/curl_cffi exception.
         """
-
         # Arrange.
         client = GarminClient()
         transport_error = requests.ConnectionError("network down")
@@ -341,11 +323,10 @@ class TestExchangeServiceTicket:
         A 200 response that omits ``refresh_token`` is treated as a parse failure and
         the exchange falls through to the next client ID.
 
-        If all three responses
-        are similarly malformed, the exchange raises ``GarminAuthenticationError``
-        rather than half-populating client state with no way to refresh later.
+        If all three responses are similarly malformed, the exchange raises
+        ``GarminAuthenticationError`` rather than half-populating client state with no
+        way to refresh later.
         """
-
         # Arrange.
         client = GarminClient()
         token = _make_jwt({"client_id": "FIRST_CID", "exp": 9999999999})
@@ -378,10 +359,8 @@ class TestRefreshDiToken:
         """
         Cannot refresh without a refresh token + client ID.
         """
-
         # Arrange.
         client = GarminClient()
-
         # Act & Assert.
         with pytest.raises(GarminAuthenticationError):
             client._refresh_di_token()
@@ -390,7 +369,6 @@ class TestRefreshDiToken:
         """
         A successful refresh updates the access + refresh + client ID.
         """
-
         # Arrange.
         client = GarminClient()
         client.di_refresh_token = "old_refresh"
@@ -417,7 +395,6 @@ class TestRefreshDiToken:
         If the refresh response does not include a new refresh token, the existing one
         is preserved (so the chain stays alive).
         """
-
         # Arrange.
         client = GarminClient()
         client.di_refresh_token = "old_refresh"
@@ -438,7 +415,6 @@ class TestRefreshDiToken:
         """
         A non-OK refresh response raises auth error.
         """
-
         # Arrange.
         client = GarminClient()
         client.di_refresh_token = "old_refresh"
@@ -458,7 +434,6 @@ class TestRefreshDiToken:
         A 429 from the DI token endpoint maps to GarminTooManyRequestsError so callers
         can distinguish rate limiting from auth failure.
         """
-
         # Arrange.
         client = GarminClient()
         client.di_refresh_token = "old_refresh"
@@ -496,17 +471,15 @@ class TestRefreshDiToken:
         post are wrapped as :class:`GarminConnectionError` so callers see consistent
         typed errors.
 
-        Both ``requests.RequestException`` (the requests-only fallback
-        path) and ``curl_cffi.requests.exceptions.RequestException`` (the production
-        cffi path) must be caught: the two hierarchies are unrelated, so a single
-        ``except requests.RequestException`` would silently leak the cffi case.
+        Both ``requests.RequestException`` (the requests-only fallback path) and
+        ``curl_cffi.requests.exceptions.RequestException`` (the production cffi path)
+        must be caught: the two hierarchies are unrelated, so a single ``except
+        requests.RequestException`` would silently leak the cffi case.
         """
-
         # Arrange.
         client = GarminClient()
         client.di_refresh_token = "old_refresh"
         client.di_client_id = "GARMIN_OLD"
-
         with patch.object(
             GarminClient,
             "_http_post",
@@ -522,12 +495,10 @@ class TestRefreshDiToken:
         edge HTML page), the JSON decode failure is wrapped as
         :class:`GarminConnectionError` with a short body preview.
         """
-
         # Arrange.
         client = GarminClient()
         client.di_refresh_token = "old_refresh"
         client.di_client_id = "GARMIN_OLD"
-
         bad_body = MagicMock()
         bad_body.ok = True
         bad_body.status_code = 200
@@ -548,7 +519,6 @@ class TestRefreshDiToken:
         A malformed refresh response is an auth-server problem, not a transport failure,
         and callers that catch auth errors should see this case.
         """
-
         # Arrange.
         client = GarminClient()
         client.di_refresh_token = "old_refresh"
@@ -575,7 +545,6 @@ class TestRefreshSession:
         After a successful in-memory refresh, the new tokens are written back to
         ``_tokenstore_path`` so the rotating chain stays alive.
         """
-
         # Arrange.
         client = GarminClient()
         client.di_token = "old_token"
@@ -606,11 +575,9 @@ class TestRefreshSession:
         Refresh failures are logged but do not propagate, so a transient DI outage
         cannot crash a long-running pipeline.
         """
-
         # Arrange.
         client = GarminClient()
         client.di_token = "old_token"
-
         with patch.object(
             client, "_refresh_di_token", side_effect=Exception("network down")
         ):
@@ -621,7 +588,6 @@ class TestRefreshSession:
         """
         An unauthenticated client has nothing to refresh.
         """
-
         # Arrange.
         client = GarminClient()
 
@@ -642,7 +608,6 @@ class TestRequest:
         """
         Build a client with a token that won't trigger pre-refresh.
         """
-
         client = GarminClient()
         client.di_token = _make_jwt(
             {"client_id": "CID", "exp": int(time.time()) + 86400}
@@ -656,7 +621,6 @@ class TestRequest:
         On HTTP 401 the client refreshes the token once and retries; the second response
         is returned to the caller.
         """
-
         # Arrange.
         client = self._build_client_with_token()
 
@@ -685,7 +649,6 @@ class TestRequest:
         """
         If the retry also returns 401 the client surfaces a typed auth error.
         """
-
         # Arrange.
         client = self._build_client_with_token()
 
@@ -707,14 +670,12 @@ class TestRequest:
         """
         HTTP 429 raises ``GarminTooManyRequestsError``.
         """
-
         # Arrange.
         client = self._build_client_with_token()
 
         rate_limited = MagicMock()
         rate_limited.status_code = 429
         rate_limited.text = "rate limited"
-
         mock_session = MagicMock()
         mock_session.request.return_value = rate_limited
 
@@ -730,7 +691,6 @@ class TestRequest:
         """
         HTTP 500-class responses raise ``GarminConnectionError``.
         """
-
         # Arrange.
         client = self._build_client_with_token()
 
@@ -756,13 +716,11 @@ class TestRequest:
         ``requests`` are wrapped as :class:`GarminConnectionError` so callers see
         consistent typed errors instead of bare ``RequestException`` subclasses.
         """
-
         # Arrange.
         client = self._build_client_with_token()
 
         mock_session = MagicMock()
         mock_session.request.side_effect = requests.ConnectionError("network down")
-
         with patch(
             "dags.pipelines.garmin.garmin_client.client.requests.Session",
             return_value=mock_session,
@@ -777,7 +735,6 @@ class TestRequest:
         wrapped as :class:`GarminConnectionError` and references the retry phase
         explicitly.
         """
-
         # Arrange.
         client = self._build_client_with_token()
 
@@ -808,13 +765,11 @@ class TestConnectapi:
         """
         A 200 response with a valid JSON body returns the parsed dict.
         """
-
         # Arrange.
         client = GarminClient()
         ok_resp = MagicMock()
         ok_resp.status_code = 200
         ok_resp.json.return_value = {"hello": "world"}
-
         with patch.object(client, "_request", return_value=ok_resp):
             # Act.
             result = client._connectapi("/some/path")
@@ -826,7 +781,6 @@ class TestConnectapi:
         """
         HTTP 204 No Content yields an empty dict so callers don't try to parse.
         """
-
         # Arrange.
         client = GarminClient()
         empty_resp = MagicMock()
@@ -846,7 +800,6 @@ class TestConnectapi:
         :class:`GarminConnectionError` with a short body preview rather than escaping as
         a bare ``JSONDecodeError``.
         """
-
         # Arrange.
         client = GarminClient()
         html_resp = MagicMock()
@@ -870,7 +823,6 @@ class TestFromTokens:
         ``from_tokens`` reads the on-disk JSON, calls ``_load_profile`` to populate the
         display name, and returns a ready client.
         """
-
         # Arrange.
         token_file = tmp_path / "garmin_tokens.json"
         token_file.write_text(
@@ -916,11 +868,9 @@ class TestLoadProfile:
         """
         A successful profile fetch sets both name attributes.
         """
-
         # Arrange.
         client = GarminClient()
         client.di_token = "stub_token"
-
         with patch.object(
             client,
             "_connectapi",
@@ -937,7 +887,6 @@ class TestLoadProfile:
         """
         A profile response without ``displayName`` raises auth error.
         """
-
         # Arrange.
         client = GarminClient()
         client.di_token = "stub_token"
@@ -959,7 +908,6 @@ class TestResumeLogin:
         returned ``("needs_mfa", ...)`` raises a typed auth error rather than leaking an
         ``AttributeError`` from the strategy module.
         """
-
         # Arrange: a fresh client has no ``_mfa_*_session`` attribute.
         client = GarminClient()
 

--- a/tests/dags/pipelines/garmin/garmin_client/test_constants.py
+++ b/tests/dags/pipelines/garmin/garmin_client/test_constants.py
@@ -30,11 +30,9 @@ class TestRandomBrowserHeaders:
         """
         The helper always returns a dict containing a User-Agent header.
 
-        ``ua_generator`` (when installed) emits lowercase header names while
-        the static fallback uses the canonical capitalized form, so this check
-        accepts either case.
+        ``ua_generator`` (when installed) emits lowercase header names while the static
+        fallback uses the canonical capitalized form, so this check accepts either case.
         """
-
         # Act.
         headers = _random_browser_headers()
 
@@ -55,7 +53,6 @@ class TestBuildBasicAuth:
         ``_build_basic_auth`` returns ``Basic <base64(client_id:)>`` per the DI OAuth2
         endpoint's expectations.
         """
-
         # Arrange.
         client_id = "GARMIN_TEST_CLIENT"
 
@@ -79,7 +76,6 @@ class TestNativeHeaders:
         Without extras the helper returns the static native Android headers including
         the GCM User-Agent and X-Garmin-User-Agent strings.
         """
-
         # Act.
         headers = _native_headers()
 
@@ -93,7 +89,6 @@ class TestNativeHeaders:
         """
         Extras override defaults when keys collide.
         """
-
         # Arrange.
         extra = {"Authorization": "Bearer abc", "User-Agent": "override"}
 
@@ -117,7 +112,6 @@ class TestModuleConstants:
         The Cloudflare-evading delay should sit in the 30-60s range and have a non-empty
         span (otherwise ``random.uniform`` would always return the same value).
         """
-
         assert 30.0 <= LOGIN_DELAY_MIN_S < LOGIN_DELAY_MAX_S
         assert LOGIN_DELAY_MAX_S <= 60.0
 
@@ -126,7 +120,6 @@ class TestModuleConstants:
         The DI exchange iterates this tuple in order, so it must be non-empty and
         contain only strings.
         """
-
         assert isinstance(DI_CLIENT_IDS, tuple)
         assert len(DI_CLIENT_IDS) >= 1
         assert all(isinstance(cid, str) and cid for cid in DI_CLIENT_IDS)
@@ -135,7 +128,6 @@ class TestModuleConstants:
         """
         The DI token endpoint and grant type are HTTPS URLs at garmin.com.
         """
-
         assert DI_TOKEN_URL.startswith("https://")
         assert "garmin.com" in DI_TOKEN_URL
         assert DI_GRANT_TYPE.startswith("https://")

--- a/tests/dags/pipelines/garmin/garmin_client/test_exceptions.py
+++ b/tests/dags/pipelines/garmin/garmin_client/test_exceptions.py
@@ -17,7 +17,6 @@ def test_too_many_requests_is_a_connection_error() -> None:
     ``GarminTooManyRequestsError`` subclasses ``GarminConnectionError`` so callers can
     catch the parent to handle all transport-level failures.
     """
-
     err = GarminTooManyRequestsError("rate limited")
     assert isinstance(err, GarminConnectionError)
     assert isinstance(err, Exception)
@@ -28,7 +27,6 @@ def test_authentication_error_is_independent() -> None:
     Authentication errors are deliberately not connection errors so credential failures
     don't get masked by a generic try/except.
     """
-
     err = GarminAuthenticationError("bad password")
     assert not isinstance(err, GarminConnectionError)
     assert isinstance(err, Exception)

--- a/tests/dags/pipelines/garmin/garmin_client/test_strategies.py
+++ b/tests/dags/pipelines/garmin/garmin_client/test_strategies.py
@@ -27,7 +27,6 @@ def mock_client() -> MagicMock:
 
     :return: MagicMock standing in for a GarminClient.
     """
-
     client = MagicMock()
     client._sso = "https://sso.garmin.com"
     return client
@@ -48,7 +47,6 @@ class TestWidgetLoginCffi:
         Without curl_cffi the widget strategy raises ``GarminConnectionError``
         immediately so the parent fallback chain advances.
         """
-
         with patch("dags.pipelines.garmin.garmin_client.strategies.HAS_CFFI", False):
             with pytest.raises(GarminConnectionError):
                 strategies.widget_login_cffi(mock_client, "u", "p")
@@ -59,7 +57,6 @@ class TestWidgetLoginCffi:
         """
         A 429 on the initial embed GET raises the typed rate-limit error.
         """
-
         # Arrange.
         rate_limited = MagicMock()
         rate_limited.status_code = 429
@@ -84,7 +81,6 @@ class TestWidgetLoginCffi:
         When the credential POST title contains 'MFA' and ``return_on_mfa`` is True, the
         strategy stashes session state and returns the sentinel tuple.
         """
-
         # Arrange.
         embed_resp = MagicMock(status_code=200, ok=True, text="<html></html>")
         signin_resp = MagicMock(
@@ -128,7 +124,6 @@ class TestWidgetLoginCffi:
         A title mentioning 'invalid' triggers ``GarminAuthenticationError`` so the
         fallback chain stops trying other strategies on bad credentials.
         """
-
         # Arrange.
         embed_resp = MagicMock(status_code=200, ok=True, text="<html></html>")
         signin_resp = MagicMock(
@@ -168,7 +163,6 @@ class TestCompleteMfaWidget:
         """
         A successful MFA verify returns the extracted service ticket.
         """
-
         # Arrange.
         last_resp = MagicMock(
             text='<input name="_csrf" value="csrf_token"/>',
@@ -199,7 +193,6 @@ class TestCompleteMfaWidget:
         """
         A non-success title raises ``GarminAuthenticationError``.
         """
-
         # Arrange.
         last_resp = MagicMock(
             text='<input name="_csrf" value="csrf_token"/>',
@@ -237,7 +230,6 @@ class TestPortalWebLogin:
         The 30-45s Cloudflare-evading delay is invoked between the SSO GET and the
         credential POST.
         """
-
         # Arrange. Mock POST returns SUCCESSFUL so the flow short-circuits.
         post_resp = MagicMock()
         post_resp.status_code = 200
@@ -266,7 +258,6 @@ class TestPortalWebLogin:
         """
         A 429 from the credential POST raises the typed rate-limit error.
         """
-
         # Arrange.
         post_resp = MagicMock()
         post_resp.status_code = 429
@@ -285,7 +276,6 @@ class TestPortalWebLogin:
         """
         ``INVALID_USERNAME_PASSWORD`` is mapped to ``GarminAuthenticationError``.
         """
-
         # Arrange.
         post_resp = MagicMock()
         post_resp.status_code = 200
@@ -306,7 +296,6 @@ class TestPortalWebLogin:
         ``MFA_REQUIRED`` with ``return_on_mfa=True`` stashes session state and returns
         the needs_mfa sentinel.
         """
-
         # Arrange.
         post_resp = MagicMock()
         post_resp.status_code = 200
@@ -340,7 +329,6 @@ class TestPortalWebLogin:
         response is non-JSON HTML, so checking ``r.ok`` first gives a better
         error message than letting ``r.json()`` fail.
         """
-
         # Arrange.
         post_resp = MagicMock()
         post_resp.status_code = 403
@@ -366,7 +354,6 @@ class TestPortalWebLogin:
         ``GarminConnectionError`` with the body preview included so the failure is
         debuggable from logs.
         """
-
         # Arrange.
         post_resp = MagicMock()
         post_resp.status_code = 200
@@ -395,7 +382,6 @@ class TestPortalWebLoginCffi:
         """
         Without curl_cffi the cffi variant raises ``GarminConnectionError``.
         """
-
         with patch("dags.pipelines.garmin.garmin_client.strategies.HAS_CFFI", False):
             with pytest.raises(GarminConnectionError):
                 strategies.portal_web_login_cffi(mock_client, "u", "p")
@@ -407,7 +393,6 @@ class TestPortalWebLoginCffi:
         If the first 4 impersonations raise transient errors, the 5th succeeds and
         returns its result.
         """
-
         # Arrange.
         successful_result = (None, None)
         call_count = {"n": 0}
@@ -439,7 +424,6 @@ class TestPortalWebLoginCffi:
         If the first impersonation gets 429'd, the wrapper must try the next one (rather
         than re-raising immediately).
         """
-
         # Arrange.
         successful_result = (None, None)
         call_count = {"n": 0}
@@ -472,7 +456,6 @@ class TestPortalWebLoginCffi:
         ``GarminConnectionError``) so the outer ``Client.login()`` strategy chain can
         detect the all-429 case and choose the right final error to surface.
         """
-
         # Arrange.
         with patch(
             "dags.pipelines.garmin.garmin_client.strategies.HAS_CFFI", True
@@ -499,7 +482,6 @@ class TestPortalWebLoginCffi:
         ``last_err``-based classifier would have raised the 429 subclass even though
         only 1 of 5 attempts actually hit rate limiting.
         """
-
         # Arrange.
         call_count = {"n": 0}
 
@@ -534,7 +516,6 @@ class TestPortalWebLoginCffi:
         including non-typed exceptions), the wrapper raises a generic
         :class:`GarminConnectionError` with the last error as cause.
         """
-
         # Arrange.
         with patch(
             "dags.pipelines.garmin.garmin_client.strategies.HAS_CFFI", True
@@ -565,7 +546,6 @@ class TestPortalLoginMobileCffi:
 
         Verify it is invoked between GET and POST.
         """
-
         # Arrange.
         post_resp = MagicMock()
         post_resp.json.return_value = {
@@ -612,7 +592,6 @@ class TestMobileLogin:
         The plain-requests mobile flow now has the same delay between GET and POST as
         the cffi variants.
         """
-
         # Arrange.
         post_resp = MagicMock()
         post_resp.status_code = 200
@@ -644,11 +623,9 @@ class TestMobileLogin:
         """
         A 429 from the credential POST raises the typed rate-limit error.
         """
-
         # Arrange.
         post_resp = MagicMock()
         post_resp.status_code = 429
-
         with patch(
             "dags.pipelines.garmin.garmin_client.strategies.requests.Session"
         ) as mock_session_cls, patch(
@@ -667,11 +644,10 @@ class TestMobileLogin:
         infrastructure (GarminConnectionError) before falling through to the JSON-based
         ``SUCCESSFUL``/``MFA_REQUIRED`` branches.
 
-        Without this guard
-        the classifier would mis-credit a backend outage as a bad-credential
-        failure, swallowing a retryable error behind ``GarminAuthenticationError``.
+        Without this guard the classifier would mis-credit a backend outage as a bad-
+        credential failure, swallowing a retryable error behind
+        ``GarminAuthenticationError``.
         """
-
         # Arrange.
         post_resp = MagicMock()
         post_resp.status_code = 500
@@ -700,12 +676,10 @@ class TestMobileLogin:
         A 429 on the initial GET raises ``GarminTooManyRequestsError`` before any delay
         is taken so we don't waste 30-45s sleeping for nothing.
         """
-
         # Arrange.
         get_resp = MagicMock()
         get_resp.status_code = 429
         get_resp.ok = False
-
         with patch(
             "dags.pipelines.garmin.garmin_client.strategies.requests.Session"
         ) as mock_session_cls, patch(
@@ -727,12 +701,10 @@ class TestMobileLogin:
         A non-2xx (e.g., 503) on the initial GET raises ``GarminConnectionError`` before
         sleeping or attempting credentials.
         """
-
         # Arrange.
         get_resp = MagicMock()
         get_resp.status_code = 503
         get_resp.ok = False
-
         with patch(
             "dags.pipelines.garmin.garmin_client.strategies.requests.Session"
         ) as mock_session_cls, patch(
@@ -750,7 +722,6 @@ class TestMobileLogin:
         Both the sign-in GET and the credential POST forward an explicit ``timeout``
         kwarg so the calls can never hang indefinitely in long-running pipelines.
         """
-
         # Arrange.
         get_resp = MagicMock()
         get_resp.status_code = 200
@@ -790,7 +761,6 @@ class TestPortalWebLoginGet:
         A 429 on the SSO sign-in GET raises ``GarminTooManyRequestsError`` immediately
         rather than sleeping 30-45s and then attempting a doomed credential POST.
         """
-
         # Arrange.
         get_resp = MagicMock()
         get_resp.status_code = 429
@@ -815,7 +785,6 @@ class TestPortalWebLoginGet:
         A non-2xx (e.g., 502 Bad Gateway) on the SSO sign-in GET raises
         ``GarminConnectionError`` before sleeping or POSTing credentials.
         """
-
         # Arrange.
         get_resp = MagicMock()
         get_resp.status_code = 502
@@ -842,7 +811,6 @@ class TestPortalLoginMobileCffiHardening:
         A 429 on the mobile sign-in GET raises ``GarminTooManyRequestsError`` before any
         delay or POST happens.
         """
-
         # Arrange.
         get_resp = MagicMock()
         get_resp.status_code = 429
@@ -875,7 +843,6 @@ class TestPortalLoginMobileCffiHardening:
         HTML page), the JSON decode failure is wrapped as :class:`GarminConnectionError`
         rather than escaping as a bare decode error.
         """
-
         # Arrange.
         get_resp = MagicMock()
         get_resp.status_code = 200
@@ -915,13 +882,11 @@ class TestCompleteMfaPortalHardening:
         A 429 from the verifyCode endpoint raises ``GarminTooManyRequestsError`` instead
         of crashing on JSON decode of an HTML rate-limit page.
         """
-
         # Arrange.
         verify_resp = MagicMock()
         verify_resp.status_code = 429
         verify_resp.ok = False
         verify_resp.text = "Too Many Requests"
-
         mock_session = MagicMock()
         mock_session.post.return_value = verify_resp
         mock_client._mfa_cffi_session = mock_session
@@ -938,7 +903,6 @@ class TestCompleteMfaPortalHardening:
         failed before it could evaluate the MFA code; this is a transport error, not a
         verification failure.
         """
-
         # Arrange.
         verify_resp = MagicMock()
         verify_resp.status_code = 500
@@ -963,7 +927,6 @@ class TestCompleteMfaPortalHardening:
         ``GarminConnectionError`` because the response is a transport/infra failure, not
         a definitive verification failure.
         """
-
         # Arrange.
         verify_resp = MagicMock()
         verify_resp.status_code = 200
@@ -991,7 +954,6 @@ class TestCompleteMfaHardening:
         """
         A 429 from the verifyCode endpoint raises ``GarminTooManyRequestsError``.
         """
-
         # Arrange.
         verify_resp = MagicMock()
         verify_resp.status_code = 429
@@ -1012,7 +974,6 @@ class TestCompleteMfaHardening:
         before evaluating the MFA code; this is a transport error, not a verification
         failure.
         """
-
         # Arrange.
         verify_resp = MagicMock()
         verify_resp.status_code = 502
@@ -1034,7 +995,6 @@ class TestCompleteMfaHardening:
         A 200 with a non-JSON body raises ``GarminConnectionError`` because the response
         is a transport/infra failure, not a verification failure.
         """
-
         # Arrange.
         verify_resp = MagicMock()
         verify_resp.status_code = 200
@@ -1066,7 +1026,6 @@ class TestCompleteMfaPortalWebAggregation:
         Build a mock client populated with the ``_mfa_portal_web_*`` attributes
         ``complete_mfa_portal_web`` expects to read.
         """
-
         client = MagicMock()
         client._sso = "https://sso.garmin.com"
         client._mfa_portal_web_session = MagicMock()
@@ -1081,13 +1040,11 @@ class TestCompleteMfaPortalWebAggregation:
         rate limiting and should raise ``GarminTooManyRequestsError`` so callers can
         apply backoff instead of treating the failure as bad credentials.
         """
-
         # Arrange.
         client = self._make_portal_web_client()
         rate_limited = MagicMock()
         rate_limited.status_code = 429
         client._mfa_portal_web_session.post.return_value = rate_limited
-
         # Act & Assert.
         with pytest.raises(GarminTooManyRequestsError):
             strategies.complete_mfa_portal_web(client, "123456")
@@ -1100,13 +1057,11 @@ class TestCompleteMfaPortalWebAggregation:
         (network down, TLS reset), the aggregate failure is infrastructure and should
         raise ``GarminConnectionError`` rather than ``GarminAuthenticationError``.
         """
-
         # Arrange.
         client = self._make_portal_web_client()
         client._mfa_portal_web_session.post.side_effect = ConnectionError(
             "network down"
         )
-
         # Act & Assert.
         with pytest.raises(GarminConnectionError) as excinfo:
             strategies.complete_mfa_portal_web(client, "123456")
@@ -1121,7 +1076,6 @@ class TestCompleteMfaPortalWebAggregation:
         transport-level failures for aggregate classification, so two non-JSON responses
         map to ``GarminConnectionError``, not ``GarminAuthenticationError``.
         """
-
         # Arrange.
         client = self._make_portal_web_client()
         html_resp = MagicMock()
@@ -1142,7 +1096,6 @@ class TestCompleteMfaPortalWebAggregation:
         verification response, and the 429 branch wins over transport (more specific
         signal that Garmin is throttling).
         """
-
         # Arrange.
         client = self._make_portal_web_client()
         rate_limited = MagicMock()
@@ -1165,7 +1118,6 @@ class TestCompleteMfaPortalWebAggregation:
 
         A real verification response is the definitive signal.
         """
-
         # Arrange.
         client = self._make_portal_web_client()
         rate_limited = MagicMock()
@@ -1193,7 +1145,6 @@ class TestCompleteMfaPortalWebAggregation:
         mis-credit this as an auth failure, which in turn would swallow retryable
         backend errors behind a GarminAuthenticationError the caller cannot retry.
         """
-
         # Arrange.
         client = self._make_portal_web_client()
         server_error = MagicMock()

--- a/tests/dags/pipelines/garmin/garmin_client/test_tokens.py
+++ b/tests/dags/pipelines/garmin/garmin_client/test_tokens.py
@@ -1,8 +1,8 @@
 """
 Unit tests for dags.pipelines.garmin.garmin_client.tokens module.
 
-Covers serialization, file I/O, and the directory-vs-file path resolution that
-the persistence helpers perform on behalf of ``GarminClient``.
+Covers serialization, file I/O, and the directory-vs-file path resolution that the
+persistence helpers perform on behalf of ``GarminClient``.
 """
 
 import json
@@ -26,7 +26,6 @@ def populated_client() -> GarminClient:
 
     :return: GarminClient instance with stub token state.
     """
-
     client = GarminClient()
     client.di_token = "stub_access_token"
     client.di_refresh_token = "stub_refresh_token"
@@ -46,7 +45,6 @@ class TestDumps:
         ``dumps`` returns a JSON string containing exactly the three DI fields in the
         format the upstream library uses.
         """
-
         # Act.
         serialized = tokens.dumps(populated_client)
 
@@ -70,7 +68,6 @@ class TestDump:
         """
         Passing a directory path appends ``garmin_tokens.json`` automatically.
         """
-
         # Act.
         tokens.dump(populated_client, tmp_path)
 
@@ -86,7 +83,6 @@ class TestDump:
         """
         A ``.json`` path is honored as-is rather than treated as a directory.
         """
-
         # Arrange.
         target = tmp_path / "subdir" / "custom.json"
 
@@ -105,7 +101,6 @@ class TestDump:
         Token files are written with mode ``0o600`` so the secret tokens are never
         readable by other users, regardless of the caller's umask.
         """
-
         # Act.
         tokens.dump(populated_client, tmp_path)
 
@@ -122,7 +117,6 @@ class TestDump:
         have drifted (e.g., a manual chmod or a stale file from a buggy older version)
         is locked back down on the next refresh.
         """
-
         # Arrange: pre-create the token file with world-readable permissions.
         token_file = tmp_path / "garmin_tokens.json"
         token_file.write_text("{}")
@@ -147,7 +141,6 @@ class TestLoad:
         """
         A dump-then-load cycle preserves all three DI fields.
         """
-
         # Arrange.
         tokens.dump(populated_client, tmp_path)
         new_client = GarminClient()
@@ -168,7 +161,6 @@ class TestLoad:
         """
         A malformed JSON string raises ``GarminConnectionError``.
         """
-
         # Arrange.
         client = GarminClient()
 
@@ -180,7 +172,6 @@ class TestLoad:
         """
         Valid JSON without ``di_token`` raises ``GarminAuthenticationError``.
         """
-
         # Arrange.
         client = GarminClient()
 
@@ -194,7 +185,6 @@ class TestLoad:
         because the client cannot refresh without it and the error would surface much
         later as a confusing KeyError.
         """
-
         # Arrange.
         client = GarminClient()
         tokenstore = json.dumps({"di_token": "stub_access", "di_client_id": "STUB_ID"})
@@ -209,7 +199,6 @@ class TestLoad:
         because the token refresh request requires the client ID in both the
         Authorization header and body.
         """
-
         # Arrange.
         client = GarminClient()
         tokenstore = json.dumps(
@@ -224,10 +213,8 @@ class TestLoad:
         """
         A missing file path raises ``GarminConnectionError``.
         """
-
         # Arrange.
         client = GarminClient()
-
         # Act & Assert.
         with pytest.raises(GarminConnectionError):
             tokens.load(client, tmp_path / "does_not_exist")

--- a/tests/dags/pipelines/garmin/test_batch.py
+++ b/tests/dags/pipelines/garmin/test_batch.py
@@ -57,7 +57,6 @@ def make_config(
     :param min_file_sets_in_batch: Minimum file sets per batch.
     :return: Mock ETLConfig instance.
     """
-
     config = MagicMock()
     config.data_dirs.process = process_dir
     config.file_types = file_types
@@ -74,7 +73,6 @@ def create_garmin_file(process_dir: Path, filename: str) -> Path:
     :param filename: Name of the file to create.
     :return: Path to the created file.
     """
-
     file_path = process_dir / filename
     file_path.touch()
     return file_path
@@ -90,7 +88,6 @@ def collect_all_filenames(serialized_batches: list) -> list[str]:
     :param serialized_batches: Output from the batch function.
     :return: Flat list of all filenames across all batches.
     """
-
     filenames = []
     for batch_tuple in serialized_batches:
         for serialized_file_set_list in batch_tuple:
@@ -107,7 +104,6 @@ def count_file_sets(serialized_batches: list) -> int:
     :param serialized_batches: Output from the batch function.
     :return: Total number of FileSets.
     """
-
     total = 0
     for batch_tuple in serialized_batches:
         for serialized_file_set_list in batch_tuple:
@@ -130,7 +126,6 @@ class TestBatchGrouping:
         Files from a single user at the same timestamp should be grouped into one
         FileSet.
         """
-
         # Arrange
         ts = "2025-08-07T12:00:00Z"
         create_garmin_file(tmp_path, f"12345678_SLEEP_{ts}.json")
@@ -160,7 +155,6 @@ class TestBatchGrouping:
         default dag_utils.batch: grouping by (user_id, timestamp) instead of timestamp
         alone prevents cross-user contamination.
         """
-
         # Arrange
         ts = "2025-08-07T12:00:00Z"
         create_garmin_file(tmp_path, f"11111111_SLEEP_{ts}.json")
@@ -192,7 +186,6 @@ class TestBatchGrouping:
         Files from the same user at different timestamps should be grouped into separate
         FileSets, one per timestamp.
         """
-
         # Arrange
         ts1 = "2025-08-07T12:00:00Z"
         ts2 = "2025-08-08T12:00:00Z"
@@ -215,7 +208,6 @@ class TestBatchGrouping:
         Two users with two timestamps each should produce four FileSets, one for each
         (user_id, timestamp) combination.
         """
-
         # Arrange
         ts1 = "2025-08-07T12:00:00Z"
         ts2 = "2025-08-08T12:00:00Z"
@@ -254,7 +246,6 @@ class TestBatchEdgeCases:
         An empty process directory should raise AirflowSkipException, signaling that
         there is no work to do for this DAG run.
         """
-
         # Arrange
         config = make_config(tmp_path)
 
@@ -266,7 +257,6 @@ class TestBatchEdgeCases:
         """
         max_process_tasks <= 0 should raise ValueError before any file processing.
         """
-
         # Arrange
         config = make_config(tmp_path, max_process_tasks=0)
 
@@ -278,7 +268,6 @@ class TestBatchEdgeCases:
         """
         min_file_sets_in_batch <= 0 should raise ValueError before any file processing.
         """
-
         # Arrange
         config = make_config(tmp_path, min_file_sets_in_batch=0)
 
@@ -291,7 +280,6 @@ class TestBatchEdgeCases:
         A file that doesn't match any configured file type pattern should raise
         ValueError, since the batch function performs a completeness check.
         """
-
         # Arrange: create a file that won't match any GarminFileTypes pattern.
         create_garmin_file(tmp_path, "12345678_UNKNOWN_TYPE_2025-08-07T12:00:00Z.json")
         config = make_config(tmp_path)
@@ -308,7 +296,6 @@ class TestBatchEdgeCases:
         The DB schema uses BIGINT for user_id, so non-numeric prefixes would fail
         downstream in the processor.
         """
-
         # Arrange: "abc" is not numeric.
         ts = "2025-08-07T12:00:00Z"
         create_garmin_file(tmp_path, f"abc_SLEEP_{ts}.json")
@@ -329,7 +316,6 @@ class TestBatchChunking:
         With max_process_tasks=2, min_file_sets_in_batch=1, and 4 FileSets (4 distinct
         timestamps), the result should be 2 batches with 2 FileSets each.
         """
-
         # Arrange: 4 timestamps for user 12345678.
         for day in range(7, 11):
             ts = f"2025-08-{day:02d}T12:00:00Z"
@@ -351,7 +337,6 @@ class TestBatchChunking:
         When the number of FileSets is less than min_file_sets_in_batch *
         max_process_tasks, all FileSets should be placed in a single batch.
         """
-
         # Arrange: 1 FileSet, but max_process_tasks=4.
         create_garmin_file(tmp_path, "12345678_SLEEP_2025-08-07T12:00:00Z.json")
         config = make_config(tmp_path, max_process_tasks=4, min_file_sets_in_batch=1)
@@ -368,7 +353,6 @@ class TestBatchChunking:
         When FileSets don't divide evenly into batches, remaining FileSets should be
         distributed round-robin across the existing batches.
         """
-
         # Arrange: 5 timestamps, max_process_tasks=2, min_file_sets_in_batch=2.
         # First pass: 2 batches of 2 = 4 file sets consumed. 1 remainder distributed
         # round-robin into batch 0.
@@ -392,7 +376,6 @@ class TestBatchChunking:
         With min_file_sets_in_batch=3 and 6 FileSets, max_process_tasks=4, we should get
         2 batches of 3 FileSets each (not 4 batches).
         """
-
         # Arrange: 6 distinct timestamps.
         for day in range(7, 13):
             ts = f"2025-08-{day:02d}T12:00:00Z"
@@ -412,7 +395,6 @@ class TestBatchChunking:
         Verify the serialized output structure matches what XCom expects:
         list of tuples, each containing a list of serialized FileSet dicts.
         """
-
         # Arrange
         ts = "2025-08-07T12:00:00Z"
         create_garmin_file(tmp_path, f"12345678_SLEEP_{ts}.json")

--- a/tests/dags/pipelines/garmin/test_process.py
+++ b/tests/dags/pipelines/garmin/test_process.py
@@ -59,12 +59,11 @@ def _make_test_processor() -> GarminProcessor:
     Construct a minimally-mocked GarminProcessor for unit tests.
 
     Shared by ``TestGarminProcessor.processor`` and
-    ``TestProcessFitSubSecond.processor`` so both classes use an identical
-    instance without duplicating the boilerplate.
+    ``TestProcessFitSubSecond.processor`` so both classes use an identical instance
+    without duplicating the boilerplate.
 
     :return: GarminProcessor instance bound to a mock ETLConfig.
     """
-
     mock_config = MagicMock(spec=ETLConfig)
     with patch("dags.lib.dag_utils.ETLResult"):
         return GarminProcessor(
@@ -88,7 +87,6 @@ class TestGarminProcessor:
 
         :return: Temporary directory path.
         """
-
         with tempfile.TemporaryDirectory() as temp_dir:
             yield Path(temp_dir)
 
@@ -99,7 +97,6 @@ class TestGarminProcessor:
 
         :return: GarminProcessor instance.
         """
-
         return _make_test_processor()
 
     @pytest.fixture
@@ -109,7 +106,6 @@ class TestGarminProcessor:
 
         :return: Mock session.
         """
-
         session = MagicMock()
         session.execute.return_value.scalars.return_value.first.return_value = None
         session.merge.return_value = None
@@ -123,7 +119,6 @@ class TestGarminProcessor:
 
         :return: Sample sleep JSON data.
         """
-
         return {
             "dailySleepDTO": {
                 "id": 123456789,
@@ -218,7 +213,6 @@ class TestGarminProcessor:
 
         :return: Sample user profile JSON data.
         """
-
         return {
             "full_name": "Test User",
             "userData": {
@@ -238,7 +232,6 @@ class TestGarminProcessor:
 
         :return: Sample activity JSON data.
         """
-
         return [
             {
                 "activityId": 987654321,
@@ -280,7 +273,6 @@ class TestGarminProcessor:
 
         :param processor: GarminProcessor fixture.
         """
-
         # Act.
         result = processor._parse_filename("123456789_SLEEP_2022-01-01T00-00-00Z.json")
 
@@ -296,7 +288,6 @@ class TestGarminProcessor:
 
         :param processor: GarminProcessor fixture.
         """
-
         # Act.
         result = processor._parse_filename(
             "123456789_ACTIVITY_987654321_2022-01-01T06-00-00Z.fit"
@@ -314,7 +305,6 @@ class TestGarminProcessor:
 
         :param processor: GarminProcessor fixture.
         """
-
         # Act & Assert.
         with pytest.raises(
             ValueError, match="Filename does not match expected pattern"
@@ -328,7 +318,6 @@ class TestGarminProcessor:
         :param processor: GarminProcessor fixture.
         :param mock_session: Mock session fixture.
         """
-
         # Arrange.
         mock_session.execute.return_value.scalars.return_value.first.return_value = None
 
@@ -347,7 +336,6 @@ class TestGarminProcessor:
         :param processor: GarminProcessor fixture.
         :param mock_session: Mock session fixture.
         """
-
         # Arrange.
         existing_user = User(user_id=123456789, full_name="Test User")
         mock_session.execute.return_value.scalars.return_value.first.return_value = (
@@ -367,7 +355,6 @@ class TestGarminProcessor:
         :param processor: GarminProcessor fixture.
         :param temp_dir: Temporary directory fixture.
         """
-
         # Arrange.
         test_data = {"test": "data"}
         test_file = temp_dir / "test.json"
@@ -386,7 +373,6 @@ class TestGarminProcessor:
 
         :param processor: GarminProcessor fixture.
         """
-
         # Act & Assert.
         assert processor._convert_field_name("camelCase") == "camel_case"
         assert processor._convert_field_name("HTTPResponse") == "h_t_t_p_response"
@@ -463,7 +449,6 @@ class TestGarminProcessor:
         :param processor: GarminProcessor fixture.
         :param mock_session: Mock session fixture.
         """
-
         # Arrange.
         sleep_data = {
             "dailySleepDTO": {
@@ -515,7 +500,6 @@ class TestGarminProcessor:
         :param processor: GarminProcessor fixture.
         :param mock_session: Mock session fixture.
         """
-
         # Arrange: dailySleepDTO without calendarDate.
         sleep_data = {
             "dailySleepDTO": {
@@ -545,7 +529,6 @@ class TestGarminProcessor:
         :param processor: GarminProcessor fixture.
         :param mock_session: Mock session fixture.
         """
-
         # Arrange.
         data = {
             "sleepLevels": [
@@ -621,10 +604,8 @@ class TestGarminProcessor:
         :param processor: GarminProcessor fixture.
         :param mock_session: Mock session fixture.
         """
-
         # Arrange: payload with no sleepLevels key.
         data = {}
-
         # Act.
         processor._process_sleep_level(data, 123456, mock_session)
 
@@ -644,7 +625,6 @@ class TestGarminProcessor:
         :param processor: GarminProcessor fixture.
         :param mock_session: Mock session fixture.
         """
-
         # Arrange: payload with only unknown stage codes.
         data = {
             "sleepLevels": [
@@ -676,7 +656,6 @@ class TestGarminProcessor:
         :param processor: GarminProcessor fixture.
         :param mock_session: Mock session fixture.
         """
-
         # Arrange.
         data = {
             "sleepMovement": [
@@ -707,7 +686,6 @@ class TestGarminProcessor:
         :param processor: GarminProcessor fixture.
         :param mock_session: Mock session fixture.
         """
-
         # Arrange.
         data = {
             "sleepRestlessMoments": [
@@ -738,7 +716,6 @@ class TestGarminProcessor:
         :param processor: GarminProcessor fixture.
         :param mock_session: Mock session fixture.
         """
-
         # Arrange.
         data = {
             "wellnessEpochSPO2DataDTOList": [
@@ -769,7 +746,6 @@ class TestGarminProcessor:
         :param processor: GarminProcessor fixture.
         :param mock_session: Mock session fixture.
         """
-
         # Arrange.
         data = {
             "hrvData": [
@@ -802,7 +778,6 @@ class TestGarminProcessor:
         :param processor: GarminProcessor fixture.
         :param mock_session: Mock session fixture.
         """
-
         # Arrange.
         data = {
             "breathingDisruptionData": [
@@ -835,7 +810,6 @@ class TestGarminProcessor:
         :param temp_dir: Temporary directory fixture.
         :param sample_user_profile_data: Sample user profile data fixture.
         """
-
         # Arrange.
         profile_file = temp_dir / "123456789_USER_PROFILE_2022-01-01T00-00-00Z.json"
         with open(profile_file, "w", encoding="utf-8") as f:
@@ -868,7 +842,6 @@ class TestGarminProcessor:
         :param temp_dir: Temporary directory fixture.
         :param sample_activity_data: Sample activity data fixture.
         """
-
         # Arrange.
         activities_file = (
             temp_dir / "123456789_ACTIVITIES_LIST_2022-01-01T00-00-00Z.json"
@@ -902,7 +875,6 @@ class TestGarminProcessor:
         :param processor: GarminProcessor fixture.
         :param mock_session: Mock session fixture.
         """
-
         # Arrange.
         activity_data = {
             "activityId": 987654321,
@@ -963,7 +935,6 @@ class TestGarminProcessor:
         :param processor: GarminProcessor fixture.
         :param mock_session: Mock session fixture.
         """
-
         # Arrange.
         activity_data = {
             "activityId": 987654321,
@@ -1101,9 +1072,10 @@ class TestGarminProcessor:
         self, mock_upsert, processor, mock_session
     ):
         """
-        Test that _process_activity_base handles missing device-related fields. This
-        ensures that historical activity data files without deviceId, manufacturer, and
-        timeZoneId fields are processed correctly with NULL values.
+        Test that _process_activity_base handles missing device-related fields.
+
+        This ensures that historical activity data files without deviceId, manufacturer,
+        and timeZoneId fields are processed correctly with NULL values.
 
         :param mock_upsert: Mock upsert function.
         :param processor: GarminProcessor fixture.
@@ -1261,9 +1233,10 @@ class TestGarminProcessor:
         self, mock_upsert, processor, mock_session
     ):
         """
-        Test that _process_activity_base handles missing activityName field. This
-        ensures that very old activity data files without activityName are processed
-        correctly with NULL value.
+        Test that _process_activity_base handles missing activityName field.
+
+        This ensures that very old activity data files without activityName are
+        processed correctly with NULL value.
 
         :param mock_upsert: Mock upsert function.
         :param processor: GarminProcessor fixture.
@@ -1333,7 +1306,6 @@ class TestGarminProcessor:
         :param temp_dir: Temporary directory fixture.
         :param sample_sleep_data: Sample sleep data fixture.
         """
-
         # Arrange.
         sleep_file = temp_dir / "123456789_SLEEP_2022-01-01T00-00-00Z.json"
         with open(sleep_file, "w", encoding="utf-8") as f:
@@ -1365,7 +1337,6 @@ class TestGarminProcessor:
 
         :return: Sample steps data list.
         """
-
         return [
             {
                 "startGMT": "2025-08-07T07:00:00.0",
@@ -1414,7 +1385,6 @@ class TestGarminProcessor:
         :param temp_dir: Temporary directory fixture.
         :param sample_steps_data: Sample steps data fixture.
         """
-
         # Arrange.
         steps_file = temp_dir / "15007510_STEPS_2025-08-07T12:00:00Z.json"
         with open(steps_file, "w", encoding="utf-8") as f:
@@ -1450,7 +1420,6 @@ class TestGarminProcessor:
         :param mock_session: Mock session fixture.
         :param temp_dir: Temporary directory fixture.
         """
-
         # Arrange.
         empty_data = []
         steps_file = temp_dir / "15007510_STEPS_2025-08-07T12:00:00Z.json"
@@ -1476,7 +1445,6 @@ class TestGarminProcessor:
         :param temp_dir: Temporary directory fixture.
         :param sample_steps_data: Sample steps data fixture.
         """
-
         # Arrange - add invalid values to the data.
         modified_data = copy.deepcopy(sample_steps_data)
         modified_data.extend(
@@ -1520,7 +1488,6 @@ class TestGarminProcessor:
         :param mock_session: Mock session fixture.
         :param temp_dir: Temporary directory fixture.
         """
-
         # Arrange.
         steps_file = temp_dir / "123456789_STEPS_2022-01-01T00:00:00Z.json"
         steps_file.write_text(
@@ -1550,7 +1517,6 @@ class TestGarminProcessor:
         :param mock_session: Mock session fixture.
         :param temp_dir: Temporary directory fixture.
         """
-
         # Arrange.
         invalid_data = {"otherData": "value"}
         sleep_file = temp_dir / "123456789_SLEEP_2022-01-01T00-00-00Z.json"
@@ -1572,7 +1538,6 @@ class TestGarminProcessor:
 
         :return: Sample training status data dictionary.
         """
-
         return {
             "userId": 15007510,
             "mostRecentVO2Max": {
@@ -1685,7 +1650,6 @@ class TestGarminProcessor:
         :param temp_dir: Temporary directory fixture.
         :param sample_training_status_data: Sample training status data fixture.
         """
-
         # Arrange.
         training_status_file = (
             temp_dir / "15007510_TRAINING_STATUS_2025-08-15T12-00-00Z.json"
@@ -1759,13 +1723,11 @@ class TestGarminProcessor:
         :param mock_session: Mock session fixture.
         :param sample_training_status_data: Sample training status data fixture.
         """
-
         # Act.
         processor.user_id = 1
         processor._process_vo2_max_and_acclimation(
             sample_training_status_data, mock_session
         )
-
         # Assert.
         # VO2Max and Acclimation records are now processed via separate
         # upsert_model_instances calls.
@@ -1831,11 +1793,9 @@ class TestGarminProcessor:
         :param mock_session: Mock session fixture.
         :param sample_training_status_data: Sample training status data fixture.
         """
-
         # Act.
         processor.user_id = 1
         processor._process_training_load(sample_training_status_data, mock_session)
-
         # Assert.
         # Should call upsert twice: once for balance, once for merged status data.
         assert mock_upsert.call_count == 2
@@ -1903,7 +1863,6 @@ class TestGarminProcessor:
         :param mock_session: Mock session fixture.
         :param sample_training_status_data: Sample training status data fixture.
         """
-
         # Arrange - modify data to have different dates.
         modified_data = copy.deepcopy(sample_training_status_data)
         modified_data["mostRecentTrainingStatus"]["latestTrainingStatusData"][
@@ -1946,14 +1905,12 @@ class TestGarminProcessor:
         :param processor: GarminProcessor fixture.
         :param mock_session: Mock session fixture.
         """
-
         # Arrange.
         empty_data = {}
 
         # Act.
         processor.user_id = 1
         processor._process_training_load(empty_data, mock_session)
-
         # Assert.
         mock_upsert.assert_not_called()  # No upsert calls with empty data.
         assert mock_session.merge.call_count == 0  # No merge calls.
@@ -1970,7 +1927,6 @@ class TestGarminProcessor:
         :param mock_session: Mock session fixture.
         :param sample_training_status_data: Sample training status data fixture.
         """
-
         # Arrange - add unexpected data types to balance data.
         modified_data = copy.deepcopy(sample_training_status_data)
         balance_data = modified_data["mostRecentTrainingLoadBalance"][
@@ -2020,7 +1976,6 @@ class TestGarminProcessor:
         :param mock_session: Mock session fixture.
         :param temp_dir: Temporary directory fixture.
         """
-
         # Arrange.
         training_status_file = (
             temp_dir / "123456789_TRAINING_STATUS_2022-01-01T00-00-00Z.json"
@@ -2056,7 +2011,6 @@ class TestGarminProcessor:
 
         :return: Sample training readiness data list.
         """
-
         return [
             {
                 "userProfilePK": 15007510,
@@ -2145,14 +2099,12 @@ class TestGarminProcessor:
         :param temp_dir: Temporary directory fixture.
         :param sample_training_readiness_data: Sample training readiness data fixture.
         """
-
         # Arrange.
         training_readiness_file = (
             temp_dir / "15007510_TRAINING_READINESS_2025-08-07T12:00:00Z.json"
         )
         with open(training_readiness_file, "w", encoding="utf-8") as f:
             json.dump(sample_training_readiness_data, f)
-
         # Mock upsert_model_instances.
         with patch(
             "dags.pipelines.garmin.process.upsert_model_instances"
@@ -2192,13 +2144,11 @@ class TestGarminProcessor:
         :param processor: GarminProcessor fixture.
         :param sample_training_readiness_data: Sample training readiness data fixture.
         """
-
         # Arrange - use first record from sample data.
         single_record = copy.deepcopy(sample_training_readiness_data[0])
 
         # Use the actual file processing logic to test field extraction.
         readiness_data = single_record
-
         # Extract and exclude fields as per implementation.
         readiness_data.pop("userProfilePK", None)
         readiness_data.pop("calendarDate", None)
@@ -2263,7 +2213,6 @@ class TestGarminProcessor:
         :param processor: GarminProcessor fixture.
         :param mock_session: Mock session fixture.
         """
-
         # Arrange.
         empty_data = []
 
@@ -2287,13 +2236,11 @@ class TestGarminProcessor:
         :param processor: GarminProcessor fixture.
         :param mock_session: Mock session fixture.
         """
-
         # Arrange.
         incomplete_data = [
             {"level": "HIGH", "score": 85},  # Missing timestamp.
             {"timestamp": "2025-08-07T12:00:00.0", "level": "LOW", "score": 30},
         ]
-
         # Act.
         with patch(
             "dags.pipelines.garmin.process.upsert_model_instances"
@@ -2319,7 +2266,6 @@ class TestGarminProcessor:
         :param mock_session: Mock session fixture.
         :param temp_dir: Temporary directory fixture.
         """
-
         # Arrange.
         training_readiness_file = (
             temp_dir / "123456789_TRAINING_READINESS_2022-01-01T00-00-00Z.json"
@@ -2330,7 +2276,6 @@ class TestGarminProcessor:
         file_set = FileSet(
             files={GARMIN_FILE_TYPES.TRAINING_READINESS: [training_readiness_file]}
         )
-
         # Mock user existence check.
         mock_session.execute.return_value.scalars.return_value.first.return_value = None
 
@@ -2360,7 +2305,6 @@ class TestGarminProcessor:
         :param processor: GarminProcessor fixture.
         :param mock_session: Mock session fixture.
         """
-
         # Arrange - data with mix of null and non-null values.
         data_with_nulls = [
             {
@@ -2421,7 +2365,6 @@ class TestGarminProcessor:
 
         :return: Sample stress JSON data.
         """
-
         return {
             "stressValuesArray": [
                 [1754550000000, 25],  # Valid stress value.
@@ -2452,7 +2395,6 @@ class TestGarminProcessor:
         :param temp_dir: Temporary directory fixture.
         :param sample_stress_data: Sample stress data fixture.
         """
-
         # Arrange.
         stress_file = temp_dir / "123456789_STRESS_2022-01-01T00-00-00Z.json"
         with open(stress_file, "w", encoding="utf-8") as f:
@@ -2497,7 +2439,6 @@ class TestGarminProcessor:
         :param mock_session: Mock session fixture.
         :param temp_dir: Temporary directory fixture.
         """
-
         # Arrange - data with negative and incomplete values.
         stress_data = {
             "stressValuesArray": [
@@ -2549,7 +2490,6 @@ class TestGarminProcessor:
         :param mock_session: Mock session fixture.
         :param temp_dir: Temporary directory fixture.
         """
-
         # Arrange - focus on body battery data.
         stress_data = {
             "stressValuesArray": [],
@@ -2601,7 +2541,6 @@ class TestGarminProcessor:
         :param mock_session: Mock session fixture.
         :param temp_dir: Temporary directory fixture.
         """
-
         # Arrange - empty arrays.
         stress_data = {
             "stressValuesArray": [],
@@ -2633,7 +2572,6 @@ class TestGarminProcessor:
         :param mock_session: Mock session fixture.
         :param temp_dir: Temporary directory fixture.
         """
-
         # Arrange - missing arrays (pop should handle gracefully).
         stress_data = {"otherData": "no stress or body battery arrays"}
 
@@ -2660,7 +2598,6 @@ class TestGarminProcessor:
         :param temp_dir: Temporary directory fixture.
         :param sample_stress_data: Sample stress data fixture.
         """
-
         # Arrange.
         stress_file = temp_dir / "123456789_STRESS_2022-01-01T00-00-00Z.json"
         with open(stress_file, "w", encoding="utf-8") as f:
@@ -2691,7 +2628,6 @@ class TestGarminProcessor:
         :param mock_session: Mock session fixture.
         :param temp_dir: Temporary directory fixture.
         """
-
         # Arrange.
         stress_file = temp_dir / "123456789_STRESS_2022-01-01T00-00-00Z.json"
         stress_file.write_text(
@@ -2722,7 +2658,6 @@ class TestGarminProcessor:
         """
         Test that Stress and BodyBattery models have correct field mappings.
         """
-
         # Act - create model instances to verify field mappings.
         test_timestamp = datetime.fromtimestamp(1640995200000 / 1000, tz=timezone.utc)
 
@@ -2755,7 +2690,6 @@ class TestGarminProcessor:
 
         :return: Sample heart rate data dictionary.
         """
-
         return {
             "userProfilePK": 15007510,
             "calendarDate": "2025-08-07",
@@ -2790,7 +2724,6 @@ class TestGarminProcessor:
         :param temp_dir: Temporary directory fixture.
         :param sample_heart_rate_data: Sample heart rate data fixture.
         """
-
         # Arrange.
         heart_rate_file = temp_dir / "15007510_HEART_RATE_2025-08-07T12:00:00Z.json"
         with open(heart_rate_file, "w", encoding="utf-8") as f:
@@ -2799,7 +2732,6 @@ class TestGarminProcessor:
         # Act.
         processor.user_id = 1
         processor._process_heart_rate(heart_rate_file, mock_session)
-
         # Assert.
         mock_upsert.assert_called_once()
         _, kwargs = mock_upsert.call_args
@@ -2827,7 +2759,6 @@ class TestGarminProcessor:
         :param mock_session: Mock session fixture.
         :param temp_dir: Temporary directory fixture.
         """
-
         # Arrange.
         data_no_values = {
             "userProfilePK": 15007510,
@@ -2858,7 +2789,6 @@ class TestGarminProcessor:
         :param mock_session: Mock session fixture.
         :param temp_dir: Temporary directory fixture.
         """
-
         # Arrange.
         data_empty_values = {
             "userProfilePK": 15007510,
@@ -2868,7 +2798,6 @@ class TestGarminProcessor:
         heart_rate_file = temp_dir / "15007510_HEART_RATE_2025-08-07T12:00:00Z.json"
         with open(heart_rate_file, "w", encoding="utf-8") as f:
             json.dump(data_empty_values, f)
-
         # Act.
         with patch(
             "dags.pipelines.garmin.process.upsert_model_instances"
@@ -2890,7 +2819,6 @@ class TestGarminProcessor:
         :param temp_dir: Temporary directory fixture.
         :param sample_heart_rate_data: Sample heart rate data fixture.
         """
-
         # Arrange - add invalid values to the data.
         modified_data = copy.deepcopy(sample_heart_rate_data)
         modified_data["heartRateValues"] = [
@@ -2932,7 +2860,6 @@ class TestGarminProcessor:
         :param mock_session: Mock session fixture.
         :param temp_dir: Temporary directory fixture.
         """
-
         # Arrange.
         heart_rate_file = temp_dir / "123456789_HEART_RATE_2022-01-01T00:00:00Z.json"
         heart_rate_file.write_text('{"heartRateValues": [[1640995200000, 65]]}')
@@ -2942,7 +2869,6 @@ class TestGarminProcessor:
 
         # Mock user existence check.
         mock_session.execute.return_value.scalars.return_value.first.return_value = None
-
         # Act.
         with patch.object(
             processor, "_process_heart_rate"
@@ -2962,7 +2888,6 @@ class TestGarminProcessor:
 
         :return: Sample respiration data dictionary.
         """
-
         return {
             "userProfilePK": 15007510,
             "calendarDate": "2025-08-07",
@@ -3022,7 +2947,6 @@ class TestGarminProcessor:
         :param temp_dir: Temporary directory fixture.
         :param sample_respiration_data: Sample respiration data fixture.
         """
-
         # Arrange.
         respiration_file = temp_dir / "15007510_RESPIRATION_2025-08-07T12:00:00Z.json"
         with open(respiration_file, "w", encoding="utf-8") as f:
@@ -3031,7 +2955,6 @@ class TestGarminProcessor:
         # Act.
         processor.user_id = 1
         processor._process_respiration(respiration_file, mock_session)
-
         # Assert.
         mock_upsert.assert_called_once()
         _, kwargs = mock_upsert.call_args
@@ -3062,7 +2985,6 @@ class TestGarminProcessor:
         :param mock_session: Mock session fixture.
         :param temp_dir: Temporary directory fixture.
         """
-
         # Arrange.
         data_no_values = {
             "userProfilePK": 15007510,
@@ -3075,7 +2997,6 @@ class TestGarminProcessor:
         respiration_file = temp_dir / "15007510_RESPIRATION_2025-08-07T12:00:00Z.json"
         with open(respiration_file, "w", encoding="utf-8") as f:
             json.dump(data_no_values, f)
-
         # Act and Assert.
         with patch("dags.lib.logging_utils.LOGGER.warning") as mock_logger:
             processor.user_id = 1
@@ -3090,7 +3011,6 @@ class TestGarminProcessor:
         :param mock_session: Mock session fixture.
         :param temp_dir: Temporary directory fixture.
         """
-
         # Arrange.
         data_empty_values = {
             "userProfilePK": 15007510,
@@ -3101,7 +3021,6 @@ class TestGarminProcessor:
         respiration_file = temp_dir / "15007510_RESPIRATION_2025-08-07T12:00:00Z.json"
         with open(respiration_file, "w", encoding="utf-8") as f:
             json.dump(data_empty_values, f)
-
         # Act and Assert.
         with patch("dags.lib.logging_utils.LOGGER.warning") as mock_logger:
             processor.user_id = 1
@@ -3120,7 +3039,6 @@ class TestGarminProcessor:
         :param mock_session: Mock session fixture.
         :param temp_dir: Temporary directory fixture.
         """
-
         # Arrange.
         data_invalid_values = {
             "userProfilePK": 15007510,
@@ -3168,7 +3086,6 @@ class TestGarminProcessor:
         :param mock_session: Mock session fixture.
         :param temp_dir: Temporary directory fixture.
         """
-
         # Arrange.
         data_no_valid_values = {
             "userProfilePK": 15007510,
@@ -3201,7 +3118,6 @@ class TestGarminProcessor:
         :param mock_session: Mock session fixture.
         :param temp_dir: Temporary directory fixture.
         """
-
         # Arrange.
         respiration_file = temp_dir / "123456789_RESPIRATION_2025-08-07T12:00:00Z.json"
         minimal_data = {
@@ -3238,7 +3154,6 @@ class TestGarminProcessor:
         :param mock_session: Mock session fixture.
         :param temp_dir: Temporary directory fixture.
         """
-
         # Arrange.
         intensity_data = {
             "userProfilePK": 15007510,
@@ -3309,7 +3224,6 @@ class TestGarminProcessor:
         :param mock_session: Mock session fixture.
         :param temp_dir: Temporary directory fixture.
         """
-
         # Arrange.
         data_no_values = {
             "userProfilePK": 15007510,
@@ -3324,7 +3238,6 @@ class TestGarminProcessor:
         )
         with open(intensity_file, "w", encoding="utf-8") as f:
             json.dump(data_no_values, f)
-
         # Act and Assert.
         with patch("dags.lib.logging_utils.LOGGER.warning") as mock_logger:
             processor.user_id = 1
@@ -3352,7 +3265,6 @@ class TestGarminProcessor:
         :param mock_session: Mock session fixture.
         :param temp_dir: Temporary directory fixture.
         """
-
         # Arrange.
         data_invalid_values = {
             "userProfilePK": 15007510,
@@ -3406,7 +3318,6 @@ class TestGarminProcessor:
         :param mock_session: Mock session fixture.
         :param temp_dir: Temporary directory fixture.
         """
-
         # Arrange.
         intensity_file = (
             temp_dir / "123456789_INTENSITY_MINUTES_2025-08-07T12:00:00Z.json"
@@ -3447,7 +3358,6 @@ class TestGarminProcessor:
         :param mock_session: Mock session fixture.
         :param temp_dir: Temporary directory fixture.
         """
-
         # Arrange.
         floors_data = {
             "userProfilePK": 15007510,
@@ -3503,7 +3413,6 @@ class TestGarminProcessor:
         :param mock_session: Mock session fixture.
         :param temp_dir: Temporary directory fixture.
         """
-
         # Arrange.
         floors_data = {
             "userProfilePK": 15007510,
@@ -3518,7 +3427,6 @@ class TestGarminProcessor:
         # Act.
         processor.user_id = 1
         processor._process_floors(floors_file, mock_session)
-
         # Assert.
         mock_upsert.assert_not_called()
 
@@ -3534,7 +3442,6 @@ class TestGarminProcessor:
         :param mock_session: Mock session fixture.
         :param temp_dir: Temporary directory fixture.
         """
-
         # Arrange.
         floors_data = {
             "userProfilePK": 15007510,
@@ -3569,7 +3476,6 @@ class TestGarminProcessor:
         :param mock_session: Mock session fixture.
         :param temp_dir: Temporary directory fixture.
         """
-
         # Arrange.
         floors_file = temp_dir / "123456789_FLOORS_2025-08-07T12:00:00Z.json"
         minimal_data = {
@@ -3600,7 +3506,6 @@ class TestGarminProcessor:
         """
         Sample personal records data for testing.
         """
-
         return [
             {
                 "id": 2071637774,
@@ -3661,7 +3566,6 @@ class TestGarminProcessor:
         """
         Test _process_personal_records with complete personal records data.
         """
-
         # Arrange.
         pr_file = temp_dir / "123456789_PERSONAL_RECORDS_2025-08-07T12:00:00Z.json"
         with open(pr_file, "w", encoding="utf-8") as f:
@@ -3674,7 +3578,6 @@ class TestGarminProcessor:
         def mock_execute_side_effect(stmt):
             result_mock = MagicMock()
             entity = stmt.column_descriptions[0]["entity"]
-
             if entity == Activity:
                 # Mock Activity queries - all activities exist for this test.
                 result_mock.scalars.return_value.first.return_value = (
@@ -3731,7 +3634,6 @@ class TestGarminProcessor:
         """
         Test _process_personal_records with latest flag management.
         """
-
         # Arrange.
         sample_data = [
             {
@@ -3748,7 +3650,6 @@ class TestGarminProcessor:
 
         user_id = 1
         processor.user_id = user_id
-
         # Mock existing latest records.
         existing_record1 = MagicMock()
         existing_record1.latest = True
@@ -3792,7 +3693,6 @@ class TestGarminProcessor:
         """
         Test _process_personal_records with missing essential data.
         """
-
         # Arrange.
         incomplete_data = [
             {"typeId": 3, "activityId": 12345},  # Missing prStartTimeGmt and value.
@@ -3806,7 +3706,6 @@ class TestGarminProcessor:
         pr_file = temp_dir / "123456789_PERSONAL_RECORDS_2025-08-07T12:00:00Z.json"
         with open(pr_file, "w", encoding="utf-8") as f:
             json.dump(incomplete_data, f)
-
         user_id = 1
         processor.user_id = user_id
 
@@ -3820,7 +3719,6 @@ class TestGarminProcessor:
         """
         Test _process_personal_records with invalid JSON format.
         """
-
         # Arrange.
         pr_file = temp_dir / "123456789_PERSONAL_RECORDS_2025-08-07T12:00:00Z.json"
         with open(pr_file, "w", encoding="utf-8") as f:
@@ -3839,7 +3737,6 @@ class TestGarminProcessor:
         """
         Test _process_personal_records with unknown type_id.
         """
-
         # Arrange.
         sample_data = [
             {
@@ -3896,7 +3793,6 @@ class TestGarminProcessor:
         """
         Test that PERSONAL_RECORDS files are properly routed to processing method.
         """
-
         # Arrange.
         pr_file = temp_dir / "123456789_PERSONAL_RECORDS_2025-08-07T12:00:00Z.json"
         with open(pr_file, "w", encoding="utf-8") as f:
@@ -3920,7 +3816,6 @@ class TestGarminProcessor:
         """
         Test that personal record type labels are correctly mapped.
         """
-
         # Verify some key mappings from the prompt.
         assert PR_TYPE_LABELS[1] == "Run: 1 km"
         assert PR_TYPE_LABELS[3] == "Run: 5 km"
@@ -3939,7 +3834,6 @@ class TestGarminProcessor:
         activity IDs that don't exist in the database yet, ensuring proper handling by
         skipping those records and logging appropriate warnings.
         """
-
         # Arrange.
         sample_data = [
             {
@@ -4038,7 +3932,6 @@ class TestGarminProcessor:
         exist in the database, ensuring all records are skipped with appropriate
         logging.
         """
-
         # Arrange.
         sample_data = [
             {
@@ -4112,7 +4005,6 @@ class TestGarminProcessor:
         Steps records should have activity_id set to NULL since they represent
         daily/weekly/monthly aggregates not tied to specific activities.
         """
-
         # Arrange.
         sample_data = [
             {
@@ -4218,7 +4110,6 @@ class TestGarminProcessor:
         """
         Sample race predictions data for testing.
         """
-
         return {
             "userId": 15007510,
             "fromCalendarDate": None,
@@ -4242,7 +4133,6 @@ class TestGarminProcessor:
         """
         Test _process_race_predictions with complete race predictions data.
         """
-
         # Arrange.
         rp_file = temp_dir / "123456789_RACE_PREDICTIONS_2025-08-07T12:00:00Z.json"
         with open(rp_file, "w", encoding="utf-8") as f:
@@ -4286,7 +4176,6 @@ class TestGarminProcessor:
         """
         Test _process_race_predictions with latest flag management.
         """
-
         # Arrange.
         sample_data = {
             "calendarDate": "2025-08-08",
@@ -4336,7 +4225,6 @@ class TestGarminProcessor:
         """
         Test _process_race_predictions with missing calendar date raises KeyError.
         """
-
         # Arrange.
         sample_data = {
             "time5K": 1200,
@@ -4361,7 +4249,6 @@ class TestGarminProcessor:
         """
         Test that RACE_PREDICTIONS files are routed correctly.
         """
-
         # Arrange.
         rp_file = temp_dir / "123456789_RACE_PREDICTIONS_2025-08-07T12:00:00Z.json"
         with open(rp_file, "w", encoding="utf-8") as f:
@@ -4388,7 +4275,6 @@ class TestGarminProcessor:
         """
         Test _process_race_predictions with partial race time data.
         """
-
         # Arrange.
         sample_data = {
             "calendarDate": "2025-08-08",
@@ -4405,7 +4291,6 @@ class TestGarminProcessor:
 
         # Mock no existing records.
         mock_session.execute.return_value.scalars.return_value.all.return_value = []
-
         # Act.
         processor._process_race_predictions(rp_file, mock_session)
 
@@ -4430,7 +4315,6 @@ class TestGarminProcessor:
         """
         Create mock FIT frame for testing.
         """
-
         frame = MagicMock()
         frame.frame_type = 4  # fitdecode.FIT_FRAME_DATA
         frame.name = "record"
@@ -4442,7 +4326,6 @@ class TestGarminProcessor:
         """
         Create mock FIT field for testing.
         """
-
         field = MagicMock()
         field.name = "heart_rate"
         field.value = 150
@@ -4453,7 +4336,6 @@ class TestGarminProcessor:
         """
         Test successful FIT file processing.
         """
-
         # Arrange.
         activity_id = 12345
         fit_file = (
@@ -4464,7 +4346,6 @@ class TestGarminProcessor:
         # Mock existing activity.
         mock_activity = MagicMock()
         mock_activity.activity_id = activity_id
-
         mock_session.execute.return_value.scalars.return_value.first.return_value = (
             mock_activity
         )
@@ -4509,7 +4390,6 @@ class TestGarminProcessor:
         Reprocessing should delete existing metrics and insert fresh data. This is the
         core fix for the UNIQUE constraint violation (#14).
         """
-
         # Arrange.
         activity_id = 12345
         fit_file = (
@@ -4572,7 +4452,6 @@ class TestGarminProcessor:
         """
         Test FIT file processing when activity doesn't exist.
         """
-
         # Arrange.
         activity_id = 12345
         fit_file = (
@@ -4590,7 +4469,6 @@ class TestGarminProcessor:
         """
         Test FIT file processing with invalid filename.
         """
-
         # Arrange.
         fit_file = temp_dir / "invalid_filename.fit"
         fit_file.write_bytes(b"dummy fit data")
@@ -4607,7 +4485,6 @@ class TestGarminProcessor:
         """
         Test that FIT file processing filters out UNKNOWN fields.
         """
-
         # Arrange.
         activity_id = 12345
         fit_file = (
@@ -4625,7 +4502,6 @@ class TestGarminProcessor:
         mock_timestamp_field = MagicMock()
         mock_timestamp_field.name = "timestamp"
         mock_timestamp_field.value = datetime(2025, 8, 7, 14, 30, tzinfo=timezone.utc)
-
         mock_valid_field = MagicMock()
         mock_valid_field.name = "heart_rate"
         mock_valid_field.value = 150
@@ -4661,7 +4537,6 @@ class TestGarminProcessor:
         """
         Test FIT file processing raises fitdecode errors.
         """
-
         # Arrange.
         activity_id = 12345
         fit_file = (
@@ -4686,7 +4561,6 @@ class TestGarminProcessor:
         """
         Test that process_file_set handles FIT files after JSON files.
         """
-
         # Arrange.
         json_file = temp_dir / "15007510_USER_PROFILE_2025-08-07T12:00:00Z.json"
         json_file.write_text(
@@ -4723,7 +4597,6 @@ class TestGarminProcessor:
         """
         Test FIT file processing with lap frames.
         """
-
         # Arrange.
         activity_id = 12345
         fit_file = (
@@ -4796,7 +4669,6 @@ class TestGarminProcessor:
         """
         Test FIT file processing with split frames.
         """
-
         # Arrange.
         activity_id = 12345
         fit_file = (
@@ -4879,7 +4751,6 @@ class TestGarminProcessor:
         """
         Test FIT file processing with lap frames containing array fields.
         """
-
         # Arrange.
         activity_id = 12345
         fit_file = (
@@ -4946,7 +4817,6 @@ class TestGarminProcessor:
         """
         Test FIT file processing with split frames containing array fields.
         """
-
         # Arrange.
         activity_id = 12345
         fit_file = (
@@ -5009,7 +4879,6 @@ class TestGarminProcessor:
         """
         Test FIT file processing with multiple lap and split frames.
         """
-
         # Arrange.
         activity_id = 12345
         fit_file = (
@@ -5136,7 +5005,6 @@ class TestGarminProcessor:
         """
         Test FIT file processing error handling for lap and split frames.
         """
-
         # Arrange.
         activity_id = 12345
         fit_file = (
@@ -5197,7 +5065,6 @@ class TestGarminProcessor:
         UNIQUE constraint violations on re-runs. Delete+insert ensures idempotent
         reprocessing regardless of which frame types are present.
         """
-
         # Arrange.
         activity_id = 12345
         fit_file = (
@@ -5248,7 +5115,6 @@ class TestGarminProcessor:
         points sorted ascending by timestamp. Records are emitted out of timestamp order
         to verify the explicit sort.
         """
-
         # Arrange.
         activity_id = 12345
         fit_file = (
@@ -5338,7 +5204,6 @@ class TestGarminProcessor:
         activity_path delete must still fire so any stale row from a prior reprocess is
         cleaned up.
         """
-
         # Arrange.
         activity_id = 12345
         fit_file = (
@@ -5411,7 +5276,6 @@ class TestGarminProcessor:
         A timestamp with only one of position_lat / position_long is dropped from the
         path; only timestamps with BOTH coordinates contribute a point.
         """
-
         # Arrange.
         activity_id = 12345
         fit_file = (
@@ -5489,7 +5353,6 @@ class TestGarminProcessor:
         Two record frames sharing the same timestamp must each contribute their own
         point to the path; the per-frame capture must not overwrite earlier samples.
         """
-
         # Arrange.
         activity_id = 12345
         fit_file = (
@@ -5579,7 +5442,6 @@ class TestGarminProcessor:
         :param processor: GarminProcessor fixture.
         :param mock_session: Mock session fixture.
         """
-
         # Arrange.
         activity_data = {
             "summarizedExerciseSets": [
@@ -5666,7 +5528,6 @@ class TestGarminProcessor:
         :param processor: GarminProcessor fixture.
         :param mock_session: Mock session fixture.
         """
-
         # Arrange.
         activity_data = {
             "summarizedExerciseSets": [
@@ -5692,10 +5553,8 @@ class TestGarminProcessor:
             "activeSets": 6,
             "totalReps": 45,
         }
-
         # Act.
         processor._process_strength_metrics(activity_data, 12345, mock_session)
-
         # Assert - only 1 record added (2 skipped for missing PK fields).
         mock_session.add_all.assert_called_once()
         records = mock_session.add_all.call_args[0][0]
@@ -5709,7 +5568,6 @@ class TestGarminProcessor:
         :param processor: GarminProcessor fixture.
         :param mock_session: Mock session fixture.
         """
-
         # Arrange.
         activity_data = {
             "totalSets": 0,
@@ -5761,7 +5619,6 @@ class TestGarminProcessor:
         :param processor: GarminProcessor fixture.
         :param mock_session: Mock session fixture.
         """
-
         # Arrange.
         processor.user_id = 123456789
         activity_data = {
@@ -5820,7 +5677,6 @@ class TestGarminProcessor:
         :param mock_session: Mock session fixture.
         :param temp_dir: Temporary directory fixture.
         """
-
         # Arrange.
         exercise_sets_data = {
             "activityId": 22320029355,
@@ -5943,7 +5799,6 @@ class TestGarminProcessor:
         :param mock_session: Mock session fixture.
         :param temp_dir: Temporary directory fixture.
         """
-
         # Arrange.
         exercise_sets_data = {
             "activityId": 22320029355,
@@ -5990,7 +5845,6 @@ class TestGarminProcessor:
         :param mock_session: Mock session fixture.
         :param temp_dir: Temporary directory fixture.
         """
-
         # Arrange.
         data = {"activityId": 12345, "exerciseSets": None}
         file_path = temp_dir / "123_EXERCISE_SETS_12345_2025-03-27.json"
@@ -6016,7 +5870,6 @@ class TestProcessFitSubSecond:
         """
         Create temporary directory for testing.
         """
-
         with tempfile.TemporaryDirectory() as td:
             yield Path(td)
 
@@ -6025,7 +5878,6 @@ class TestProcessFitSubSecond:
         """
         Create mock SQLAlchemy session for testing.
         """
-
         session = MagicMock()
         return session
 
@@ -6034,7 +5886,6 @@ class TestProcessFitSubSecond:
         """
         Create a GarminProcessor instance via the shared module-level helper.
         """
-
         return _make_test_processor()
 
     def test_fractional_timestamp_preserves_subsecond_precision(
@@ -6045,7 +5896,6 @@ class TestProcessFitSubSecond:
         values produce two distinct rows with sub-second precision (no UNIQUE constraint
         collision).
         """
-
         # Arrange.
         activity_id = 12345
         fit_file = (
@@ -6115,7 +5965,6 @@ class TestProcessFitSubSecond:
 
         Prevents UNIQUE constraint failure on (activity_id, timestamp, name).
         """
-
         activity_id = 12345
         fit_file = (
             temp_dir / f"15007510_ACTIVITY_{activity_id}_2025-08-07T12:00:00Z.fit"

--- a/tests/dags/pipelines/garmin/utility_scripts/test_refresh_garmin_tokens.py
+++ b/tests/dags/pipelines/garmin/utility_scripts/test_refresh_garmin_tokens.py
@@ -37,7 +37,6 @@ class TestGarminTokenRefresh:
 
         :return: Mock GarminClient instance.
         """
-
         return MagicMock()
 
     @pytest.fixture
@@ -48,7 +47,6 @@ class TestGarminTokenRefresh:
         :param mock_client_instance: Mock GarminClient instance fixture.
         :return: Tuple of mock class and mock instance.
         """
-
         with patch(
             "dags.pipelines.garmin.utility_scripts.refresh_garmin_tokens.GarminClient"
         ) as mock_class:
@@ -59,7 +57,6 @@ class TestGarminTokenRefresh:
         """
         Test successful input validation.
         """
-
         # Arrange & Act.
         result = _validate_input("test@example.com", "Email")
 
@@ -70,7 +67,6 @@ class TestGarminTokenRefresh:
         """
         Test input validation with empty value.
         """
-
         # Act & Assert.
         with pytest.raises(ValueError, match="❌ Email is required."):
             _validate_input("", "Email")
@@ -86,7 +82,6 @@ class TestGarminTokenRefresh:
 
         :param mock_logger: Mock logger instance.
         """
-
         # Act.
         email, password = get_credentials()
 
@@ -105,7 +100,6 @@ class TestGarminTokenRefresh:
         :param mock_logger: Mock logger instance.
         :param _mock_input: Mock input function (unused but needed for patching).
         """
-
         # Act.
         email, password = get_credentials()
 
@@ -123,7 +117,6 @@ class TestGarminTokenRefresh:
         :param mock_logger: Mock logger instance.
         :param _mock_input: Mock input function (unused but needed for patching).
         """
-
         # Act.
         mfa_code = get_mfa_code()
 
@@ -140,7 +133,6 @@ class TestGarminTokenRefresh:
         :param mock_logger: Mock logger instance.
         :param _mock_input: Mock input function (unused but needed for patching).
         """
-
         # Act.
         mfa_code = get_mfa_code()
 
@@ -156,7 +148,6 @@ class TestGarminTokenRefresh:
 
         :param mock_client_class_with_instance: Mock GarminClient class fixture.
         """
-
         # Arrange.
         _mock_class, mock_client_instance = mock_client_class_with_instance
         result2 = "mfa_token"
@@ -179,7 +170,6 @@ class TestGarminTokenRefresh:
 
         :param mock_client_class_with_instance: Mock GarminClient class fixture.
         """
-
         # Arrange.
         _mock_class, mock_client_instance = mock_client_class_with_instance
         mock_client_instance.resume_login.side_effect = [
@@ -209,7 +199,6 @@ class TestGarminTokenRefresh:
 
         :param mock_client_class_with_instance: Mock GarminClient class fixture.
         """
-
         # Arrange.
         _mock_class, mock_client_instance = mock_client_class_with_instance
         mock_client_instance.resume_login.side_effect = Exception("Invalid MFA")
@@ -232,7 +221,6 @@ class TestGarminTokenRefresh:
         :param mock_client_class_with_instance: Mock GarminClient class fixture.
         :param tmp_path: Pytest temporary path fixture.
         """
-
         # Arrange.
         mock_class, mock_client_instance = mock_client_class_with_instance
         mock_client_instance.login.return_value = None  # No MFA required.
@@ -261,7 +249,6 @@ class TestGarminTokenRefresh:
         :param mock_client_class_with_instance: Mock GarminClient class fixture.
         :param tmp_path: Pytest temporary path fixture.
         """
-
         # Arrange.
         mock_class, mock_client_instance = mock_client_class_with_instance
         mock_client_instance.login.return_value = ("needs_mfa", "mfa_token")
@@ -294,7 +281,6 @@ class TestGarminTokenRefresh:
         :param mock_client_class_with_instance: Mock GarminClient class fixture.
         :param tmp_path: Pytest temporary path fixture.
         """
-
         # Arrange.
         _mock_class, mock_client_instance = mock_client_class_with_instance
         mock_client_instance.login.side_effect = Exception("401 Unauthorized")
@@ -328,7 +314,6 @@ class TestRefreshTokensMultiAccount:
 
         :return: Mock GarminClient instance.
         """
-
         return MagicMock()
 
     @pytest.fixture
@@ -339,7 +324,6 @@ class TestRefreshTokensMultiAccount:
         :param mock_client_instance: Mock GarminClient instance fixture.
         :return: Tuple of mock class and mock instance.
         """
-
         with patch(
             "dags.pipelines.garmin.utility_scripts.refresh_garmin_tokens.GarminClient"
         ) as mock_class:
@@ -358,7 +342,6 @@ class TestRefreshTokensMultiAccount:
         :param mock_client_class_with_instance: Mock GarminClient class fixture.
         :param tmp_path: Pytest temporary path fixture.
         """
-
         # Arrange.
         _mock_class, mock_client_instance = mock_client_class_with_instance
         mock_client_instance.login.return_value = None  # No MFA required.
@@ -388,7 +371,6 @@ class TestRefreshTokensMultiAccount:
         :param mock_client_class_with_instance: Mock GarminClient class fixture.
         :param tmp_path: Pytest temporary path fixture.
         """
-
         # Arrange.
         _mock_class, mock_client_instance = mock_client_class_with_instance
         mock_client_instance.login.return_value = None  # No MFA required.
@@ -419,7 +401,6 @@ class TestRefreshTokensMultiAccount:
         :param mock_client_class_with_instance: Mock GarminClient class fixture.
         :param tmp_path: Pytest temporary path fixture.
         """
-
         # Arrange.
         _mock_class, mock_client_instance = mock_client_class_with_instance
         mock_client_instance.login.return_value = ("needs_mfa", "mfa_token")

--- a/tests/dags/pipelines/linkedin/test_process.py
+++ b/tests/dags/pipelines/linkedin/test_process.py
@@ -36,7 +36,6 @@ class TestLinkedInProcessor:
 
         :return: Temporary directory path.
         """
-
         with tempfile.TemporaryDirectory() as temp_dir:
             yield Path(temp_dir)
 
@@ -47,7 +46,6 @@ class TestLinkedInProcessor:
 
         :return: LinkedInProcessor instance.
         """
-
         mock_config = MagicMock(spec=ETLConfig)
 
         with patch("dags.lib.dag_utils.ETLResult"):
@@ -65,7 +63,6 @@ class TestLinkedInProcessor:
 
         :return: Mock session.
         """
-
         session = MagicMock()
         session.execute.return_value.scalars.return_value = iter([])
         return session
@@ -77,7 +74,6 @@ class TestLinkedInProcessor:
 
         :return: Sample CSV content with header notes.
         """
-
         return """Notes:
 "Connections are exported from LinkedIn."
 
@@ -95,7 +91,6 @@ Bob,Wilson,https://www.linkedin.com/in/bobwilson,bob@test.com,Startup LLC,Develo
         """
         Test parsing valid LinkedIn date format.
         """
-
         result = processor._parse_date("09 Jan 2024")
         assert result == date(2024, 1, 9)
 
@@ -103,7 +98,6 @@ Bob,Wilson,https://www.linkedin.com/in/bobwilson,bob@test.com,Startup LLC,Develo
         """
         Test parsing dates with various months.
         """
-
         test_cases = [
             ("01 Feb 2024", date(2024, 2, 1)),
             ("15 Mar 2023", date(2023, 3, 15)),
@@ -119,7 +113,6 @@ Bob,Wilson,https://www.linkedin.com/in/bobwilson,bob@test.com,Startup LLC,Develo
         """
         Test parsing empty date string returns None.
         """
-
         result = processor._parse_date("")
         assert result is None
 
@@ -127,7 +120,6 @@ Bob,Wilson,https://www.linkedin.com/in/bobwilson,bob@test.com,Startup LLC,Develo
         """
         Test parsing whitespace-only string returns None.
         """
-
         result = processor._parse_date("   ")
         assert result is None
 
@@ -135,7 +127,6 @@ Bob,Wilson,https://www.linkedin.com/in/bobwilson,bob@test.com,Startup LLC,Develo
         """
         Test parsing None returns None.
         """
-
         result = processor._parse_date(None)
         assert result is None
 
@@ -143,7 +134,6 @@ Bob,Wilson,https://www.linkedin.com/in/bobwilson,bob@test.com,Startup LLC,Develo
         """
         Test parsing invalid date format returns None.
         """
-
         result = processor._parse_date("2024-01-09")
         assert result is None
 
@@ -151,7 +141,6 @@ Bob,Wilson,https://www.linkedin.com/in/bobwilson,bob@test.com,Startup LLC,Develo
         """
         Test parsing invalid date value returns None.
         """
-
         result = processor._parse_date("32 Jan 2024")
         assert result is None
 
@@ -163,7 +152,6 @@ Bob,Wilson,https://www.linkedin.com/in/bobwilson,bob@test.com,Startup LLC,Develo
         """
         Test extracting capture date from valid filename.
         """
-
         file_path = Path("/some/path/Connections_20240115.csv")
         result = processor._extract_capture_date(file_path)
         assert result == date(2024, 1, 15)
@@ -174,7 +162,6 @@ Bob,Wilson,https://www.linkedin.com/in/bobwilson,bob@test.com,Startup LLC,Develo
         """
         Test extracting capture dates from various filenames.
         """
-
         test_cases = [
             (Path("Connections_20230101.csv"), date(2023, 1, 1)),
             (Path("Connections_20241231.csv"), date(2024, 12, 31)),
@@ -191,7 +178,6 @@ Bob,Wilson,https://www.linkedin.com/in/bobwilson,bob@test.com,Startup LLC,Develo
         """
         Test extracting capture date from filename without date returns None.
         """
-
         file_path = Path("Connections.csv")
         result = processor._extract_capture_date(file_path)
         assert result is None
@@ -202,7 +188,6 @@ Bob,Wilson,https://www.linkedin.com/in/bobwilson,bob@test.com,Startup LLC,Develo
         """
         Test extracting capture date from filename with invalid date returns None.
         """
-
         # Invalid month (13).
         file_path = Path("Connections_20241301.csv")
         result = processor._extract_capture_date(file_path)
@@ -218,7 +203,6 @@ Bob,Wilson,https://www.linkedin.com/in/bobwilson,bob@test.com,Startup LLC,Develo
         """
         Test parsing CSV file that includes header notes.
         """
-
         csv_file = temp_dir / "Connections.csv"
         csv_file.write_text(sample_csv_content)
 
@@ -239,10 +223,8 @@ Bob,Wilson,https://www.linkedin.com/in/bobwilson,bob@test.com,Startup LLC,Develo
         """
         Test parsing CSV file with empty optional fields.
         """
-
         csv_file = temp_dir / "Connections.csv"
         csv_file.write_text(sample_csv_content)
-
         result = processor._parse_csv_file(csv_file)
 
         # Jane Smith has no email.
@@ -256,7 +238,6 @@ Bob,Wilson,https://www.linkedin.com/in/bobwilson,bob@test.com,Startup LLC,Develo
         """
         Test parsing CSV file without valid header row returns empty list.
         """
-
         csv_content = """This is not a valid CSV.
 Some random text.
 """
@@ -273,7 +254,6 @@ Some random text.
         """
         Test parsing CSV file where header is at a different line number.
         """
-
         csv_content = """Line 1 notes.
 Line 2 more notes.
 Line 3 even more notes.
@@ -305,10 +285,8 @@ Test,User,https://www.linkedin.com/in/testuser,test@test.com,Test Co,Tester,01 J
         """
         Test that processing a CSV file creates Connection instances.
         """
-
         csv_file = temp_dir / "Connections_20240115.csv"
         csv_file.write_text(sample_csv_content)
-
         with patch(
             "dags.pipelines.linkedin.process.upsert_model_instances"
         ) as mock_upsert:
@@ -332,10 +310,8 @@ Test,User,https://www.linkedin.com/in/testuser,test@test.com,Test Co,Tester,01 J
         """
         Test that all processed connections have active_connection=True.
         """
-
         csv_file = temp_dir / "Connections_20240115.csv"
         csv_file.write_text(sample_csv_content)
-
         with patch(
             "dags.pipelines.linkedin.process.upsert_model_instances"
         ) as mock_upsert:
@@ -354,10 +330,8 @@ Test,User,https://www.linkedin.com/in/testuser,test@test.com,Test Co,Tester,01 J
         """
         Test that dates are correctly parsed into date objects.
         """
-
         csv_file = temp_dir / "Connections_20240115.csv"
         csv_file.write_text(sample_csv_content)
-
         with patch(
             "dags.pipelines.linkedin.process.upsert_model_instances"
         ) as mock_upsert:
@@ -382,10 +356,8 @@ Test,User,https://www.linkedin.com/in/testuser,test@test.com,Test Co,Tester,01 J
         """
         Test that empty optional fields are converted to None.
         """
-
         csv_file = temp_dir / "Connections_20240115.csv"
         csv_file.write_text(sample_csv_content)
-
         with patch(
             "dags.pipelines.linkedin.process.upsert_model_instances"
         ) as mock_upsert:
@@ -406,10 +378,8 @@ Test,User,https://www.linkedin.com/in/testuser,test@test.com,Test Co,Tester,01 J
         """
         Test that capture_date is extracted from filename and set on all connections.
         """
-
         csv_file = temp_dir / "Connections_20240115.csv"
         csv_file.write_text(sample_csv_content)
-
         with patch(
             "dags.pipelines.linkedin.process.upsert_model_instances"
         ) as mock_upsert:
@@ -431,10 +401,8 @@ Test,User,https://www.linkedin.com/in/testuser,test@test.com,Test Co,Tester,01 J
         """
         Test that upsert is called with latest_check_column for capture_date.
         """
-
         csv_file = temp_dir / "Connections_20240115.csv"
         csv_file.write_text(sample_csv_content)
-
         with patch(
             "dags.pipelines.linkedin.process.upsert_model_instances"
         ) as mock_upsert:
@@ -453,7 +421,6 @@ Test,User,https://www.linkedin.com/in/testuser,test@test.com,Test Co,Tester,01 J
         """
         Test that rows with empty URL are skipped.
         """
-
         csv_content = """Notes:
 Header notes here.
 
@@ -464,7 +431,6 @@ Jane,Smith,https://www.linkedin.com/in/janesmith,,Tech Inc,Manager,15 Feb 2024
 
         csv_file = temp_dir / "Connections_20240115.csv"
         csv_file.write_text(csv_content)
-
         with patch(
             "dags.pipelines.linkedin.process.upsert_model_instances"
         ) as mock_upsert:
@@ -484,7 +450,6 @@ Jane,Smith,https://www.linkedin.com/in/janesmith,,Tech Inc,Manager,15 Feb 2024
         """
         Test processing a file with no connections.
         """
-
         csv_content = """Notes:
 Header notes here.
 
@@ -493,7 +458,6 @@ First Name,Last Name,URL,Email Address,Company,Position,Connected On
 
         csv_file = temp_dir / "Connections_20240115.csv"
         csv_file.write_text(csv_content)
-
         with patch(
             "dags.pipelines.linkedin.process.upsert_model_instances"
         ) as mock_upsert:
@@ -512,7 +476,6 @@ First Name,Last Name,URL,Email Address,Company,Position,Connected On
         """
         Test that connections not in file are marked as inactive via bulk UPDATE.
         """
-
         # Track execute calls to distinguish select from update.
         execute_call_count = [0]
         scalars_mock = MagicMock()
@@ -570,7 +533,6 @@ First Name,Last Name,URL,Email Address,Company,Position,Connected On
         """
         Test that no update when all DB connections are in file.
         """
-
         # Mock the URL query result (scalars returns URL strings).
         scalars_mock = MagicMock()
         scalars_mock.scalars.return_value = [
@@ -593,12 +555,10 @@ First Name,Last Name,URL,Email Address,Company,Position,Connected On
         """
         Test handling when database has no active connections.
         """
-
         # Mock the URL query result (scalars returns empty list).
         scalars_mock = MagicMock()
         scalars_mock.scalars.return_value = []
         mock_session.execute.return_value = scalars_mock
-
         active_urls: Set[str] = {"https://www.linkedin.com/in/newuser"}
         capture_date = date(2024, 1, 15)
 
@@ -621,7 +581,6 @@ First Name,Last Name,URL,Email Address,Company,Position,Connected On
         """
         Test that process_file_set processes all files in the file set.
         """
-
         csv_file = temp_dir / "Connections_20240115.csv"
         csv_file.write_text(sample_csv_content)
 
@@ -642,13 +601,11 @@ First Name,Last Name,URL,Email Address,Company,Position,Connected On
         """
         Test that process_file_set handles multiple files.
         """
-
         csv_file_1 = temp_dir / "Connections_20240115.csv"
         csv_file_1.write_text(sample_csv_content)
 
         csv_file_2 = temp_dir / "Connections_20240116.csv"
         csv_file_2.write_text(sample_csv_content)
-
         file_set = FileSet(
             files={LinkedInFileTypes.CONNECTIONS: [csv_file_1, csv_file_2]}
         )


### PR DESCRIPTION
## Summary

Cleanup PR addressing format-drift and a real bug exposed after PR #135 narrowed the Makefile's docformatter exit-code allow-list from `{1, 3}` to `{3}` only.

### Changes

1. **Apply docformatter docstring cleanup across ~30 files** (blank-line removal, summary splitting). Pure cosmetic, no behavior change.

2. **Fix `DO NOTHING.` SQL typo in `dags/pipelines/garmin/process.py:246`**: the user-creation INSERT had a literal trailing period (`ON CONFLICT (user_id) DO NOTHING.`). That period is part of the SQL string and would cause a runtime syntax error. Rewrote to a properly-formatted multi-string concatenation. (Caught by Copilot review.)

3. **Rewrite 5 `text("""...""")` patterns in `tests/dags/lib/test_sql_utils.py`** to implicit string concatenation. The old `text(""" <weirdly-indented SQL> """)` pattern caused an infinite black-vs-docformatter ping-pong; the new form satisfies both:
   ```python
   text(
       "CREATE TEMP TABLE foo ("
       " id INTEGER PRIMARY KEY,"
       " ...)"
   )
   ```

4. **Add `.venv`/`venv`/`.git`/`build`/`dist` to docformatter `exclude` in `pyproject.toml`**: docformatter recursing into `.venv` previously *corrupted* a third-party `mypy_extensions.py` (its `_int_type.__doc__ = """..."""\.format(...)` construct), causing subsequent `make format` runs to fail when black tried to import the now-broken mypy_extensions. The exclude prevents this self-inflicted filesystem damage on fresh venvs.

### Known limitation (not fixed)

`dags/pipelines/garmin/garmin_client/exceptions.py` has an unresolvable black-vs-docformatter conflict on blank-line count between module docstring and the first class definition (black wants 2, docformatter wants 1). Neither tool honors per-file overrides cleanly. **`make check-format` will still report this single file as needing formatting** — same state as PR #137 had at merge. Listed as a known follow-up.

## Test plan

- [x] `make format` converges (no infinite loops)
- [x] DO NOTHING typo fix verified by inspecting process.py:246
- [x] All 5 SQL string rewrites in test_sql_utils.py preserve test semantics (column names + types unchanged, only formatting)
- [ ] CI Tests still green
- [ ] CI Code Quality fails ONLY on the known exceptions.py limitation