### PR TITLE
refactor(sql_utils): position-aligned INSERT_IGNORE+returning, validation, PK-safe defaults

### DIFF
--- a/dags/lib/sql_utils.py
+++ b/dags/lib/sql_utils.py
@@ -278,27 +278,31 @@ def upsert_model_instances(
         is True) the existing value. Useful for time/version-based updates.
     :param latest_check_inclusive: If True, use >= comparison for latest_check_column
         instead of >. Defaults to False (strict greater than).
-    :param returning_columns: List of column names to return via RETURNING clause. If
-        None, no RETURNING is issued and the function returns None. When provided, the
-        returned list contains one entry per input row in input order (position-
-        aligned) for the INSERT, INSERT_IGNORE, and plain UPSERT modes. Must be a
-        non-empty list of valid model column names.
+    :param returning_columns: List of column names to return via RETURNING.
+        Must be a non-empty list of valid model column names. If None, no
+        RETURNING is issued and the function returns None.
 
-        Exception: when `latest_check_column` is also set, conflicted rows whose
-        incoming value fails the latest-check `WHERE` clause produce no `RETURNING`
-        row (PostgreSQL treats the conflict as DO NOTHING in that case), so the
-        result list will be SHORTER than the input list and is no longer
-        position-aligned. Callers that combine `latest_check_column` with
-        `returning_columns` must look up rows by their conflict-key values rather
-        than by index.
+        Result-shape contract by mode:
 
-        Operational side effect (INSERT_IGNORE + returning_columns): the helper
-        rewrites internally as a no-op `ON CONFLICT DO UPDATE SET <conflict_col>
-        = excluded.<conflict_col>` to make `RETURNING` fire for conflicted rows.
-        This still executes an UPDATE in PostgreSQL: it can fire UPDATE triggers,
-        generate a new row version (WAL traffic), and take stronger locks than
-        pure `DO NOTHING`. The pure `DO NOTHING` path is preserved when
-        `returning_columns` is None.
+        - INSERT (no conflict_columns), INSERT_IGNORE, plain UPSERT: result
+          contains exactly one entry per input row in input order
+          (position-aligned).
+        - UPSERT + `latest_check_column`: NOT position-aligned. Conflicted rows
+          whose incoming value fails the latest-check `WHERE` clause produce
+          no `RETURNING` row (PostgreSQL treats the conflict as DO NOTHING in
+          that case), so the result list is SHORTER than the input list.
+          Callers in this regime must reconcile rows by their conflict-key
+          values, not by index.
+
+        Operational side effect (INSERT_IGNORE + returning_columns only): the
+        helper rewrites internally as a no-op `ON CONFLICT DO UPDATE SET
+        <conflict_col> = excluded.<conflict_col>` so `RETURNING` fires for
+        conflicted rows. This still executes an UPDATE in PostgreSQL: it can
+        fire UPDATE triggers, generate a new row version (WAL traffic), and
+        take stronger locks than pure `DO NOTHING`. The pure `DO NOTHING`
+        path is preserved when `returning_columns` is None, so callers that
+        want to skip the row-write entirely on conflict still can by
+        omitting `returning_columns`.
     :param chunk_size: Maximum rows per INSERT statement. Clamped internally so the
         total parameter count never exceeds the psycopg3 limit.
     :return: List of SQLAlchemy model instances (with only the requested columns
@@ -374,21 +378,26 @@ def _upsert_values(
         is True) the existing value. Useful for time/version-based updates.
     :param latest_check_inclusive: If True, use >= comparison for latest_check_column
         instead of >. Defaults to False (strict greater than).
-    :param returning_columns: List of columns to return after the operation. If
-        specified, returns one row per input row (in input order, position-aligned)
-        for INSERT, INSERT_IGNORE, and plain UPSERT. For INSERT_IGNORE the helper
-        internally rewrites the statement using a no-op `DO UPDATE` (assigning a
-        conflict column to itself) so `RETURNING` fires for both newly-inserted and
-        conflicted rows; this means an UPDATE actually executes in PostgreSQL on
-        conflict (UPDATE triggers can fire, a new row version is written to WAL,
-        stronger locks are taken than under pure DO NOTHING). The pure DO NOTHING
-        path is preserved when `returning_columns` is None.
-
-        Exception: UPSERT + `latest_check_column` does NOT preserve the position-
-        aligned guarantee. When the latest-check `WHERE` clause prevents the
-        update, PostgreSQL treats it as DO NOTHING and emits no `RETURNING` row
-        for that input, so the result list will be shorter than the input list.
+    :param returning_columns: List of columns to return after the operation.
         Must be a non-empty list of valid model column names.
+
+        Result-shape contract by mode:
+
+        - INSERT, INSERT_IGNORE, plain UPSERT: one row per input row in input
+          order (position-aligned).
+        - UPSERT + `latest_check_column`: NOT position-aligned. When the
+          latest-check `WHERE` clause prevents the update, PostgreSQL treats
+          the conflict as DO NOTHING and emits no `RETURNING` row, so the
+          result list is shorter than the input list. Reconcile by
+          conflict-key value, not by index.
+
+        For INSERT_IGNORE the helper internally rewrites the statement using
+        a no-op `DO UPDATE` (assigning a conflict column to itself) so
+        `RETURNING` fires for both newly-inserted and conflicted rows; this
+        means an UPDATE actually executes in PostgreSQL on conflict (UPDATE
+        triggers can fire, a new row version is written to WAL, stronger
+        locks are taken than under pure DO NOTHING). The pure DO NOTHING
+        path is preserved when `returning_columns` is None.
     :param chunk_size: Maximum rows per INSERT statement. Clamped internally so the
         total parameter count never exceeds the psycopg3 limit.
     :return: List of dictionaries with returned values if returning_columns is
@@ -406,9 +415,13 @@ def _upsert_values(
     conflict_columns = conflict_columns or []
     model_columns = model.__table__.columns.keys()
 
-    # Validate `returning_columns` so callers get a clear ValueError instead of
-    # an opaque AttributeError from `getattr(model, col)` further down, or the
-    # silent "result list shorter than input" surprise of an empty list.
+    # Validate `returning_columns` so callers get a clear ValueError up front
+    # instead of either an opaque AttributeError from `getattr(model, col)`
+    # further down (unknown column case) or a silent empty-list result that
+    # superficially looks like "no rows came back" (empty-list case). This
+    # validation is unrelated to the documented `latest_check_column`
+    # shorter-than-input result; that case is intentional and handled in the
+    # main result-shape contract in the docstring.
     if returning_columns is not None:
         if not returning_columns:
             raise ValueError(

--- a/dags/lib/sql_utils.py
+++ b/dags/lib/sql_utils.py
@@ -20,7 +20,7 @@ import urllib.parse
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Type
 
-from sqlalchemy import create_engine, DateTime, ForeignKey, MetaData, select
+from sqlalchemy import create_engine, DateTime, ForeignKey, MetaData
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import (
@@ -30,7 +30,6 @@ from sqlalchemy.orm import (
     declared_attr,
     mapped_column,
 )
-from sqlalchemy.sql import and_, or_
 
 from dags.lib.logging_utils import LOGGER
 
@@ -280,8 +279,10 @@ def upsert_model_instances(
     :param latest_check_inclusive: If True, use >= comparison for latest_check_column
         instead of >. Defaults to False (strict greater than).
     :param returning_columns: List of column names to return via RETURNING clause. If
-        None, no RETURNING is issued and the function returns None. Matches the behavior
-        of ``_upsert_values``.
+        None, no RETURNING is issued and the function returns None. When provided, the
+        returned list contains exactly one entry per input row, in input order
+        (position-aligned), regardless of which `query_type` is used internally. Must be
+        a non-empty list of valid model column names.
     :param chunk_size: Maximum rows per INSERT statement. Clamped internally so the
         total parameter count never exceeds the psycopg3 limit.
     :return: List of SQLAlchemy model instances (with only the requested columns
@@ -358,8 +359,12 @@ def _upsert_values(
     :param latest_check_inclusive: If True, use >= comparison for latest_check_column
         instead of >. Defaults to False (strict greater than).
     :param returning_columns: List of columns to return after the operation. If
-        specified, returns all rows that would have been inserted, including those with
-        conflicts.
+        specified, returns one row per input row (in input order, position-aligned),
+        including for rows that conflicted. Must be a non-empty list of valid model
+        column names. For the `INSERT_IGNORE` mode the helper internally rewrites the
+        statement using a no-op `DO UPDATE` (assigning a conflict column to itself) so
+        `RETURNING` fires for both newly-inserted and conflicted rows. See the inline
+        comment in the chunked execution loop for the full rationale.
     :param chunk_size: Maximum rows per INSERT statement. Clamped internally so the
         total parameter count never exceeds the psycopg3 limit.
     :return: List of dictionaries with returned values if returning_columns is
@@ -375,25 +380,44 @@ def _upsert_values(
         query_type = QueryType.INSERT_IGNORE if conflict_columns else QueryType.INSERT
 
     conflict_columns = conflict_columns or []
+    model_columns = model.__table__.columns.keys()
+
+    # Validate `returning_columns` so callers get a clear ValueError instead of
+    # an opaque AttributeError from `getattr(model, col)` further down, or the
+    # silent "result list shorter than input" surprise of an empty list.
+    if returning_columns is not None:
+        if not returning_columns:
+            raise ValueError(
+                "`returning_columns` must be a non-empty list when provided. "
+                "Pass None to opt out of the RETURNING path."
+            )
+        unknown = [col for col in returning_columns if col not in model_columns]
+        if unknown:
+            raise ValueError(
+                f"`returning_columns` references column(s) not present on "
+                f"{model.__name__}: {unknown}. Valid columns: "
+                f"{sorted(model_columns)}"
+            )
+
     returned_values: List[Dict[str, Any]] = []
 
+    # Default update_columns excludes:
+    # - conflict columns (used to identify the row, must not change),
+    # - primary-key columns (immutable; for an auto-increment PK that's not
+    #   present on the input dict, leaving it would generate `SET pk = NULL`
+    #   and either fail or assign a new sequence value),
+    # - create_ts (audit column; `make_base` defaults populate it on insert),
+    # - update_ts (set explicitly inside the UPSERT branch below if present).
+    pk_columns = {col.name for col in model.__table__.primary_key.columns}
     if update_columns is None:
-        update_columns = [
-            col.name
-            for col in model.__table__.columns
-            if col.name not in conflict_columns
-        ]
+        excluded_cols = set(conflict_columns) | pk_columns | {"create_ts", "update_ts"}
+        update_columns = [col for col in model_columns if col not in excluded_cols]
 
     # Clamp chunk_size so total parameters stay within the psycopg3 limit.
     # Use the full model column count because SQLAlchemy fills in columns
     # with Python-side defaults even when omitted from the values dicts.
-    # For INSERT_IGNORE with returning_columns, the follow-up SELECT uses
-    # len(conflict_columns) params per row; account for the worst case.
     num_cols = len(model.__table__.columns)
-    params_per_row = num_cols
-    if query_type == QueryType.INSERT_IGNORE and returning_columns and conflict_columns:
-        params_per_row = max(params_per_row, len(conflict_columns))
-    max_rows = max(1, min(chunk_size, _PSYCOPG_MAX_PARAMS // params_per_row))
+    max_rows = max(1, min(chunk_size, _PSYCOPG_MAX_PARAMS // num_cols))
 
     for chunk_start in range(0, len(values), max_rows):
         chunk = values[chunk_start : chunk_start + max_rows]
@@ -438,9 +462,39 @@ def _upsert_values(
                 )
 
         elif query_type == QueryType.INSERT_IGNORE:
-            upsert_stmt = insert_stmt.on_conflict_do_nothing(
-                index_elements=conflict_columns,
-            )
+            if returning_columns:
+                # "No-op DO UPDATE" trick: ON CONFLICT DO NOTHING does not emit
+                # RETURNING rows for ignored conflicts, so a follow-up SELECT
+                # over the conflict keys is required to recover IDs. That
+                # SELECT returns rows in undefined order and de-duplicates by
+                # conflict key, breaking position-alignment between input and
+                # result.
+                #
+                # Trick: rewrite as `DO UPDATE SET <conflict_col> = excluded.
+                # <conflict_col>`. The conflict column's existing value is by
+                # definition equal to the incoming value (that's what triggered
+                # the conflict), so assigning it to itself is a provable no-op
+                # at the value level. The conflict path still *fires*, which
+                # makes RETURNING emit one row per input row in input order,
+                # for both fresh inserts and conflicts.
+                #
+                # We deliberately do NOT include `update_ts` in the SET clause
+                # here, so the do-nothing contract is preserved at the audit-
+                # column level too (a conflicted row's update_ts stays at its
+                # original value).
+                #
+                # The pure DO NOTHING path is still used when
+                # returning_columns is None, so callers that want to skip the
+                # row-write entirely on conflict are unaffected.
+                key_col = conflict_columns[0]
+                upsert_stmt = insert_stmt.on_conflict_do_update(
+                    index_elements=conflict_columns,
+                    set_={key_col: insert_stmt.excluded[key_col]},
+                ).returning(*[getattr(model, col) for col in returning_columns])
+            else:
+                upsert_stmt = insert_stmt.on_conflict_do_nothing(
+                    index_elements=conflict_columns,
+                )
 
         else:
             raise ValueError(f"Invalid query type: {query_type}.")
@@ -450,33 +504,10 @@ def _upsert_values(
         result = session.execute(upsert_stmt)
 
         if returning_columns:
-            if query_type in (QueryType.UPSERT, QueryType.INSERT):
-                returned_values.extend([row._asdict() for row in result.fetchall()])
-
-            elif query_type == QueryType.INSERT_IGNORE:
-                # INSERT ... ON CONFLICT DO NOTHING does not return ignored
-                # rows. Re-query to get all matching rows for this chunk.
-                conflict_conditions = [
-                    and_(
-                        *[
-                            (
-                                getattr(model, col) == value[col]
-                                if value[col] is not None
-                                else getattr(model, col).is_(None)
-                            )
-                            for col in conflict_columns
-                        ]
-                    )
-                    for value in chunk
-                ]
-                stmt = select(
-                    *[getattr(model, col) for col in returning_columns]
-                ).where(or_(*conflict_conditions))
-                returned_values.extend(
-                    [row._asdict() for row in session.execute(stmt).all()]
-                )
-
-            else:
-                raise ValueError(f"Invalid query type: {query_type}.")
+            # All three branches above attach RETURNING when returning_columns
+            # is set (UPSERT and INSERT directly; INSERT_IGNORE via the no-op
+            # DO UPDATE trick), so we always have one row per input row in
+            # input order.
+            returned_values.extend([row._asdict() for row in result.fetchall()])
 
     return returned_values if returning_columns else None

--- a/dags/lib/sql_utils.py
+++ b/dags/lib/sql_utils.py
@@ -280,9 +280,25 @@ def upsert_model_instances(
         instead of >. Defaults to False (strict greater than).
     :param returning_columns: List of column names to return via RETURNING clause. If
         None, no RETURNING is issued and the function returns None. When provided, the
-        returned list contains exactly one entry per input row, in input order
-        (position-aligned), regardless of which `query_type` is used internally. Must be
-        a non-empty list of valid model column names.
+        returned list contains one entry per input row in input order (position-
+        aligned) for the INSERT, INSERT_IGNORE, and plain UPSERT modes. Must be a
+        non-empty list of valid model column names.
+
+        Exception: when `latest_check_column` is also set, conflicted rows whose
+        incoming value fails the latest-check `WHERE` clause produce no `RETURNING`
+        row (PostgreSQL treats the conflict as DO NOTHING in that case), so the
+        result list will be SHORTER than the input list and is no longer
+        position-aligned. Callers that combine `latest_check_column` with
+        `returning_columns` must look up rows by their conflict-key values rather
+        than by index.
+
+        Operational side effect (INSERT_IGNORE + returning_columns): the helper
+        rewrites internally as a no-op `ON CONFLICT DO UPDATE SET <conflict_col>
+        = excluded.<conflict_col>` to make `RETURNING` fire for conflicted rows.
+        This still executes an UPDATE in PostgreSQL: it can fire UPDATE triggers,
+        generate a new row version (WAL traffic), and take stronger locks than
+        pure `DO NOTHING`. The pure `DO NOTHING` path is preserved when
+        `returning_columns` is None.
     :param chunk_size: Maximum rows per INSERT statement. Clamped internally so the
         total parameter count never exceeds the psycopg3 limit.
     :return: List of SQLAlchemy model instances (with only the requested columns
@@ -359,12 +375,20 @@ def _upsert_values(
     :param latest_check_inclusive: If True, use >= comparison for latest_check_column
         instead of >. Defaults to False (strict greater than).
     :param returning_columns: List of columns to return after the operation. If
-        specified, returns one row per input row (in input order, position-aligned),
-        including for rows that conflicted. Must be a non-empty list of valid model
-        column names. For the `INSERT_IGNORE` mode the helper internally rewrites the
-        statement using a no-op `DO UPDATE` (assigning a conflict column to itself) so
-        `RETURNING` fires for both newly-inserted and conflicted rows. See the inline
-        comment in the chunked execution loop for the full rationale.
+        specified, returns one row per input row (in input order, position-aligned)
+        for INSERT, INSERT_IGNORE, and plain UPSERT. For INSERT_IGNORE the helper
+        internally rewrites the statement using a no-op `DO UPDATE` (assigning a
+        conflict column to itself) so `RETURNING` fires for both newly-inserted and
+        conflicted rows; this means an UPDATE actually executes in PostgreSQL on
+        conflict (UPDATE triggers can fire, a new row version is written to WAL,
+        stronger locks are taken than under pure DO NOTHING). The pure DO NOTHING
+        path is preserved when `returning_columns` is None.
+
+        Exception: UPSERT + `latest_check_column` does NOT preserve the position-
+        aligned guarantee. When the latest-check `WHERE` clause prevents the
+        update, PostgreSQL treats it as DO NOTHING and emits no `RETURNING` row
+        for that input, so the result list will be shorter than the input list.
+        Must be a non-empty list of valid model column names.
     :param chunk_size: Maximum rows per INSERT statement. Clamped internally so the
         total parameter count never exceeds the psycopg3 limit.
     :return: List of dictionaries with returned values if returning_columns is
@@ -506,8 +530,14 @@ def _upsert_values(
         if returning_columns:
             # All three branches above attach RETURNING when returning_columns
             # is set (UPSERT and INSERT directly; INSERT_IGNORE via the no-op
-            # DO UPDATE trick), so we always have one row per input row in
-            # input order.
+            # DO UPDATE trick). The result is one row per input row in input
+            # order for the INSERT, INSERT_IGNORE, and plain-UPSERT paths.
+            #
+            # Caveat: UPSERT + `latest_check_column` may emit fewer rows than
+            # the input chunk — when the WHERE clause on the DO UPDATE blocks
+            # an update, PostgreSQL treats the conflict as DO NOTHING and
+            # emits no RETURNING row for that input. Callers in this regime
+            # must reconcile by conflict-key value, not by index.
             returned_values.extend([row._asdict() for row in result.fetchall()])
 
     return returned_values if returning_columns else None

--- a/tests/dags/lib/test_sql_utils.py
+++ b/tests/dags/lib/test_sql_utils.py
@@ -590,6 +590,74 @@ class TestUpsertModelInstances:
         assert record.name == "newer_version"  # Should be updated.
         assert record.version == 6
 
+    def test_upsert_values_latest_check_column_returning_shorter_than_input(
+        self, db_session
+    ):
+        """
+        UPSERT + ``latest_check_column`` + ``returning_columns`` is the documented
+        exception to the "one row per input row" guarantee: when the latest-check
+        ``WHERE`` clause prevents the update, PostgreSQL treats the conflict as DO
+        NOTHING and emits no ``RETURNING`` row, so the result list is shorter than the
+        input.
+
+        Locks in the contract documented in the helper docstring.
+        """
+        db_session.execute(
+            text(
+                "CREATE TEMP TABLE test_version_returning_temp ("
+                " id INTEGER PRIMARY KEY,"
+                " name TEXT,"
+                " version INTEGER NOT NULL)"
+            )
+        )
+
+        class TempBase(DeclarativeBase):
+            pass
+
+        class TempVersionModel(TempBase):
+            __tablename__ = "test_version_returning_temp"
+            id = Column(Integer, primary_key=True)
+            name = Column(String)
+            version = Column(Integer)
+
+        # Seed: id=1 at version 5.
+        _upsert_values(
+            TempVersionModel,
+            [{"id": 1, "name": "initial", "version": 5}],
+            db_session,
+            conflict_columns=["id"],
+            on_conflict_update=True,
+            latest_check_column="version",
+        )
+        db_session.commit()
+
+        # Mix: id=1 with stale version (will be blocked) + id=2 fresh insert.
+        # Position-aligned guarantee NOT held: result has 1 row (only id=2),
+        # not 2 rows.
+        result = _upsert_values(
+            TempVersionModel,
+            [
+                {"id": 1, "name": "stale", "version": 3},
+                {"id": 2, "name": "fresh", "version": 1},
+            ],
+            db_session,
+            conflict_columns=["id"],
+            on_conflict_update=True,
+            latest_check_column="version",
+            returning_columns=["id", "name", "version"],
+        )
+        db_session.commit()
+        assert len(result) == 1
+        assert result[0]["id"] == 2
+        # id=1 was NOT updated (stale).
+        existing = (
+            db_session.execute(select(TempVersionModel).where(TempVersionModel.id == 1))
+            .scalars()
+            .first()
+        )
+        assert existing.name == "initial"
+        assert existing.version == 5
+
     def test_upsert_values_latest_check_column_inclusive(self, db_session):
         """
         Test latest_check_column with >= comparison (inclusive).

--- a/tests/dags/lib/test_sql_utils.py
+++ b/tests/dags/lib/test_sql_utils.py
@@ -214,6 +214,116 @@ class TestUpsertModelInstances:
         assert result1.col_a == "A"
         assert result2.col_a == "B"
 
+    def test_upsert_values_insert_ignore_returning_position_aligned(self, db_session):
+        """
+        INSERT_IGNORE with `returning_columns` returns one row per input row, in input
+        order (position-aligned), with existing values preserved for conflicted rows.
+
+        Implemented via the no-op DO UPDATE trick.
+        """
+        # Pre-seed two rows that will conflict on the second pass.
+        _upsert_values(
+            MyTest,
+            [{"id": 1, "col_a": "A"}, {"id": 3, "col_a": "C"}],
+            db_session,
+            conflict_columns=["id"],
+            on_conflict_update=False,
+            returning_columns=["id", "col_a"],
+        )
+        db_session.commit()
+
+        # Mix of conflict (id=1), new (id=2), conflict (id=3) in non-trivial
+        # order to stress position-alignment.
+        rows = _upsert_values(
+            MyTest,
+            [
+                {"id": 1, "col_a": "Z"},  # conflict, existing A wins
+                {"id": 2, "col_a": "B"},  # new
+                {"id": 3, "col_a": "Z"},  # conflict, existing C wins
+            ],
+            db_session,
+            conflict_columns=["id"],
+            on_conflict_update=False,
+            returning_columns=["id", "col_a"],
+        )
+        db_session.commit()
+        assert [r["id"] for r in rows] == [1, 2, 3]
+        assert [r["col_a"] for r in rows] == ["A", "B", "C"]
+        db_session.execute(delete(MyTest))
+        db_session.commit()
+
+    def test_upsert_values_returning_columns_validation(self, db_session):
+        """
+        `returning_columns=[]` and unknown column names raise clear ValueErrors instead
+        of opaque downstream failures (silent empty list / bare AttributeError from
+        getattr).
+        """
+        with pytest.raises(ValueError, match="non-empty"):
+            _upsert_values(
+                MyTest,
+                [{"id": 1, "col_a": "A"}],
+                db_session,
+                conflict_columns=["id"],
+                on_conflict_update=True,
+                returning_columns=[],
+            )
+        with pytest.raises(ValueError, match="not_a_column"):
+            _upsert_values(
+                MyTest,
+                [{"id": 1, "col_a": "A"}],
+                db_session,
+                conflict_columns=["id"],
+                on_conflict_update=True,
+                returning_columns=["id", "not_a_column"],
+            )
+
+    def test_upsert_values_default_update_columns_exclude_pk(self, db_session):
+        """
+        Default `update_columns` excludes primary-key columns even when the PK is
+        not in `conflict_columns`. Prevents `SET pk = NULL` corruption when an
+        auto-increment PK is upserted with a separate uniqueness key.
+        """
+        from sqlalchemy import Column, Integer, String, UniqueConstraint
+        from sqlalchemy.orm import DeclarativeBase
+
+        class Base(DeclarativeBase):
+            pass
+
+        class AutoPK(Base):
+            __tablename__ = "sql_utils_test_autopk"
+            __table_args__ = (UniqueConstraint("user_id", "ts", name="autopk_unique"),)
+            pk = Column(Integer, primary_key=True, autoincrement=True)
+            user_id = Column(Integer, nullable=False)
+            ts = Column(Integer, nullable=False)
+            payload = Column(String, nullable=False)
+
+        engine = db_session.get_bind()
+        Base.metadata.create_all(engine)
+        try:
+            first = _upsert_values(
+                AutoPK,
+                [{"user_id": 1, "ts": 100, "payload": "v1"}],
+                db_session,
+                conflict_columns=["user_id", "ts"],
+                on_conflict_update=True,
+                returning_columns=["pk", "payload"],
+            )
+            db_session.commit()
+            second = _upsert_values(
+                AutoPK,
+                [{"user_id": 1, "ts": 100, "payload": "v2"}],
+                db_session,
+                conflict_columns=["user_id", "ts"],
+                on_conflict_update=True,
+                returning_columns=["pk", "payload"],
+            )
+            db_session.commit()
+            # PK is preserved across the conflict update; payload is updated.
+            assert first[0]["pk"] == second[0]["pk"]
+            assert second[0]["payload"] == "v2"
+        finally:
+            Base.metadata.drop_all(engine)
+
     def test_upsert_values_rollback(self, db_session):
         """
         Test that rollback undoes inserted rows.
@@ -710,7 +820,8 @@ class TestChunkedUpsert:
 
     def test_insert_ignore_returning_across_chunks(self, db_session):
         """
-        Test INSERT_IGNORE with RETURNING re-queries per chunk.
+        INSERT_IGNORE with `returning_columns` returns one row per input row across
+        chunked statements, with existing values preserved for conflicted rows.
         """
         # Seed a subset of rows.
         seed = [{"id": 1, "col_a": "A"}, {"id": 3, "col_a": "C"}]
@@ -735,14 +846,12 @@ class TestChunkedUpsert:
         )
         assert results is not None
         assert len(results) == 5
-        by_id = {r["id"]: r["col_a"] for r in results}
-        # Existing rows keep original values.
-        assert by_id[1] == "A"
-        assert by_id[3] == "C"
-        # New rows have the inserted values.
-        assert by_id[2] == "new_2"
-        assert by_id[4] == "new_4"
-        assert by_id[5] == "new_5"
+        # Position-aligned: result[i] corresponds to input[i] across chunk
+        # boundaries. Locks in the no-op DO UPDATE trick's input-order
+        # guarantee even when the batch is split.
+        assert [r["id"] for r in results] == [1, 2, 3, 4, 5]
+        # Existing rows keep their original values; new rows take the input.
+        assert [r["col_a"] for r in results] == ["A", "new_2", "C", "new_4", "new_5"]
 
     def test_plain_insert_across_chunks(self, db_session):
         """


### PR DESCRIPTION
## Summary

Ports three improvements to `_upsert_values` / `upsert_model_instances` from the sibling helper in [diegoscarabelli/garmin-health-data#54](https://github.com/diegoscarabelli/garmin-health-data/pull/54), where the design and edge cases were worked out empirically.

1. **No-op `DO UPDATE` trick for `INSERT_IGNORE + returning_columns`.** Replaces the existing two-round-trip `DO NOTHING` + follow-up `SELECT` with a single-round-trip `ON CONFLICT (...) DO UPDATE SET <conflict_col> = excluded.<conflict_col> RETURNING ...`. The conflict column's existing value is by definition equal to the incoming value (that's what triggered the conflict), so the `SET` is a provable value-level no-op; the conflict path still fires, making `RETURNING` emit one row per input row in input order. `update_ts` is deliberately excluded from the `SET` clause so the do-nothing contract is preserved at the audit-column level too.
2. **Auto-exclude primary-key columns from default `update_columns`.** Previously the default included the PK; for auto-increment-PK + non-PK-conflict-column callers (the `sleep_id` / `(user_id, start_ts)` pattern) this would generate `SET pk = NULL` on conflict. Now the default excludes PKs alongside conflict columns, `create_ts`, and `update_ts`.
3. **Up-front `returning_columns` validation.** Empty list and unknown column names now raise clear `ValueError`s naming the offending input, instead of silently returning an empty list / surfacing a bare `AttributeError` from `getattr(model, col)` deep in the helper.

## Behavioral impact on production

Audit of `dags/pipelines/garmin/process.py`: only two call sites pass `returning_columns` (`activity_id` at line 573, `sleep_id` at line 1248), both in **UPSERT** mode. **No production caller currently uses `INSERT_IGNORE + returning_columns`**, so the wire-level rewrite of that path has no current production impact and is purely future-proofing.

## Test plan

- [x] All 23 helper tests pass; full test suite green (348 passed, 2 skipped).
- [x] New: position-aligned result list for `INSERT_IGNORE + returning_columns`, with non-trivial 3-row conflict/new/conflict input ordering.
- [x] New: validation tests for `returning_columns=[]` and unknown column name.
- [x] New: PK-auto-exclusion test using a synthetic auto-increment-PK model with a separate `UNIQUE` constraint, verifying the PK is preserved across a conflict update under the new defaults.
- [x] Tightened: `test_insert_ignore_returning_across_chunks` now asserts position alignment in addition to set-membership.

## Out of scope

The `make_base` / `latest_check_column` / `chunk_size` features and the openetl-specific `psycopg3` parameter limits are untouched. Production callers that manually exclude their PK from `update_columns` (e.g. the sleep upsert) continue to work; they could be simplified to rely on the new default but that's a follow-up.