### PR TITLE
feat(garmin): port 2.11.x train (menstrual cycle + RANGE per-window + activity dedup)

### DIFF
--- a/dags/iam.sql
+++ b/dags/iam.sql
@@ -148,6 +148,11 @@ GRANT DELETE ON garmin.activity_ts_metric TO airflow_garmin;
 GRANT DELETE ON garmin.activity_split_metric TO airflow_garmin;
 GRANT DELETE ON garmin.activity_lap_metric TO airflow_garmin;
 GRANT DELETE ON garmin.activity_path TO airflow_garmin;
+-- menstrual_cycle_tag: delete-then-reinsert per (user_id, date) so user-removed
+-- tags propagate. menstrual_cycle_summary: wipe-and-replace predicted_cycle=true
+-- rows on each extract because Garmin's projection dates shift between runs.
+GRANT DELETE ON garmin.menstrual_cycle_tag TO airflow_garmin;
+GRANT DELETE ON garmin.menstrual_cycle_summary TO airflow_garmin;
 
 -- Set default privileges for future objects in garmin schema.
 ALTER DEFAULT PRIVILEGES IN SCHEMA garmin

--- a/dags/pipelines/garmin/constants.py
+++ b/dags/pipelines/garmin/constants.py
@@ -20,6 +20,7 @@ class APIMethodTimeParam(Enum):
     DAILY = "daily"  # Single date parameter: get_method(date_str).
     RANGE = "range"  # Date range parameters: get_method(start_str, end_str).
     NO_DATE = "no_date"  # No date parameters: get_method().
+    PER_ACTIVITY = "per_activity"  # Called per activity_id by extract_fit_activities.
 
 
 @dataclass
@@ -33,7 +34,7 @@ class GarminDataType:
 
     name: str  # "SLEEP".
     api_method: str  # "get_sleep_data()".
-    api_method_time_param: APIMethodTimeParam  # DAILY/RANGE/NO_DATE.
+    api_method_time_param: APIMethodTimeParam  # DAILY/RANGE/NO_DATE/PER_ACTIVITY.
     api_endpoint: str  # API endpoint string.
     description: str  # Description of the data type.
     emoji: str  # Emoji for pretty logging.
@@ -54,6 +55,7 @@ class GarminDataRegistry:
             APIMethodTimeParam.DAILY: [],
             APIMethodTimeParam.RANGE: [],
             APIMethodTimeParam.NO_DATE: [],
+            APIMethodTimeParam.PER_ACTIVITY: [],
         }
         self._all_data_types: List[GarminDataType] = []
 
@@ -174,7 +176,7 @@ class GarminDataRegistry:
             GarminDataType(
                 "EXERCISE_SETS",
                 "get_activity_exercise_sets",
-                APIMethodTimeParam.RANGE,
+                APIMethodTimeParam.PER_ACTIVITY,
                 "/activity-service/activity/{activity_id}/exerciseSets",
                 "Per-set granular strength training data with ML-classified "
                 "exercises, reps, weight, duration, and set type.",
@@ -212,7 +214,7 @@ class GarminDataRegistry:
             GarminDataType(
                 "ACTIVITY",
                 "download_activity",
-                APIMethodTimeParam.RANGE,
+                APIMethodTimeParam.PER_ACTIVITY,
                 "/download-service/files/activity/{activity_id}",
                 "Binary FIT files containing detailed time-series activity data.",
                 "🏃",
@@ -293,6 +295,15 @@ class GarminDataRegistry:
         :return: List of data types with NO_DATE time parameter.
         """
         return self.get_by_time_param(APIMethodTimeParam.NO_DATE)
+
+    @property
+    def per_activity_data_types(self) -> List[GarminDataType]:
+        """
+        Get all per-activity data types (shorthand).
+
+        :return: List of data types with PER_ACTIVITY time parameter.
+        """
+        return self.get_by_time_param(APIMethodTimeParam.PER_ACTIVITY)
 
 
 def _create_garmin_file_types() -> type:

--- a/dags/pipelines/garmin/constants.py
+++ b/dags/pipelines/garmin/constants.py
@@ -154,6 +154,16 @@ class GarminDataRegistry:
                 "time-series data and goal tracking.",
                 "⚡",
             ),
+            GarminDataType(
+                "MENSTRUAL_CYCLE_DAY",
+                "get_menstrual_data_for_date",
+                APIMethodTimeParam.DAILY,
+                "/periodichealth-service/menstrualcycle/dayview/{date}",
+                "Per-day menstrual cycle state: phase, day-in-cycle, predicted cycle "
+                "length, plus user-logged data (symptoms, moods, discharge, flow, "
+                "sex drive, sexual activity, notes, ovulation flag).",
+                "🩸",
+            ),
             # Range Data - Date range parameters: get_method(start_str, end_str)
             GarminDataType(
                 "BODY_COMPOSITION",
@@ -172,6 +182,16 @@ class GarminDataRegistry:
                 "/activitylist-service/activities/search/activities",
                 "Numerous aggregated metrics for user-recorded activities.",
                 "📋",
+            ),
+            GarminDataType(
+                "MENSTRUAL_CYCLE_SUMMARY",
+                "get_menstrual_calendar_data",
+                APIMethodTimeParam.RANGE,
+                "/periodichealth-service/menstrualcycle/calendar",
+                "Per-cycle summaries (observed cycles and Garmin's projections). "
+                "Predicted cycles are wiped and re-inserted on every extract; "
+                "observed cycles upsert by (user_id, start_date).",
+                "📅",
             ),
             GarminDataType(
                 "EXERCISE_SETS",
@@ -358,6 +378,20 @@ class SleepStage(IntEnum):
     LIGHT = 1
     REM = 2
     AWAKE = 3
+
+
+class MenstrualCyclePhase(IntEnum):
+    """
+    Phase classification for menstrual cycle days from Garmin's periodic-health service.
+
+    Values are the integer codes returned in dayview.daySummary.currentPhase. Names are
+    persisted in garmin.menstrual_cycle_day.current_phase as denormalized labels.
+    """
+
+    MENSTRUAL = 1
+    FOLLICULAR = 2
+    OVULATORY = 3
+    LUTEAL = 4
 
 
 PR_TYPE_LABELS = {

--- a/dags/pipelines/garmin/constants.py
+++ b/dags/pipelines/garmin/constants.py
@@ -33,7 +33,7 @@ class GarminDataType:
     """
 
     name: str  # "SLEEP".
-    api_method: str  # "get_sleep_data()".
+    api_method: str  # GarminClient attribute name, e.g. "get_sleep_data".
     api_method_time_param: APIMethodTimeParam  # DAILY/RANGE/NO_DATE/PER_ACTIVITY.
     api_endpoint: str  # API endpoint string.
     description: str  # Description of the data type.

--- a/dags/pipelines/garmin/extract.py
+++ b/dags/pipelines/garmin/extract.py
@@ -55,8 +55,10 @@ def _with_retries(fn: Callable, *args, **kwargs):
 
     Retries only on the connection / DNS / timeout exception classes listed in
     ``_TRANSIENT_API_EXCEPTIONS``. Other exceptions propagate immediately so the
-    caller's broader try/except (e.g. per-date isolation in
-    :meth:`GarminExtractor._extract_day_by_day`) can record the failure once and move
+    caller's broader try/except (per-date isolation in
+    :meth:`GarminExtractor._extract_day_by_day`, per-window isolation in
+    :meth:`GarminExtractor._extract_range`, or per-activity isolation in
+    :meth:`GarminExtractor.extract_fit_activities`) can record the failure once and move
     on.
 
     :param fn: Callable to invoke.
@@ -94,11 +96,12 @@ class ExtractionFailure:
         account in the end-of-run summary. May be ``""`` if the failure occurred before
         authentication.
     :ivar data_type: Garmin data type name (e.g. ``"SLEEP"``, ``"ACTIVITY"``).
-    :ivar date: Date context for the failure. Most commonly an ISO date string (``"YYYY-
-        MM-DD"``) for per-date failures, but may also be a date range string like
-        ``"<start>..<end>"`` (e.g. for ``ACTIVITIES_LIST`` failures that span the whole
-        run window) or ``""`` when no date context applies (per-data-type or per-
-        activity failures).
+    :ivar date: Date context for the failure. Typically an ISO date string (``"YYYY-MM-
+        DD"``) for per-day (DAILY-type) failures, a range string ``"<start>..<end>"``
+        for any RANGE-type failure (the API call is per-window, so the failure label
+        covers the whole window even when the response would have been split into per-
+        day files on success), or ``""`` when no date context applies (per-data-type or
+        per-activity failures).
     :ivar activity_id: Activity ID as a string for per-activity failures, or ``""``
         otherwise.
     :ivar error: Human-readable error description (typically ``"<ExceptionType>:
@@ -321,15 +324,16 @@ class GarminExtractor:
         self, data_type: GarminDataType, start_date: date, end_date: date
     ) -> List[Path]:
         """
-        Extract a Garmin data type one day at a time with per-date error isolation.
+        Extract a DAILY-typed Garmin data type one day at a time with per-date error
+        isolation.
 
-        Handles both DAILY and RANGE API time parameter patterns. Each per-day API call
-        goes through ``_with_retries`` so transient network blips absorb silently. A
-        failure that exhausts retries is logged and recorded in :attr:`failures`;
-        extraction continues with the next date so a single bad day never aborts the
-        rest of the date range.
+        Each per-day API call goes through ``_with_retries`` so transient network blips
+        absorb silently. A failure that exhausts retries is logged and recorded in
+        :attr:`failures`; extraction continues with the next date so a single bad day
+        never aborts the rest of the date range. RANGE-typed data types are extracted by
+        :meth:`_extract_range` with a single API call covering the full window.
 
-        :param data_type: GarminDataType defining the extraction parameters.
+        :param data_type: GarminDataType with DAILY time parameter.
         :param start_date: Start date for data extraction (inclusive).
         :param end_date: End date for data extraction (inclusive).
         :return: List of saved file paths.
@@ -345,11 +349,7 @@ class GarminExtractor:
 
             try:
                 api_method = getattr(self.garmin_client, data_type.api_method)
-                if data_type.api_method_time_param == APIMethodTimeParam.DAILY:
-                    data = _with_retries(api_method, date_str)
-                else:
-                    # Pass the same date to both params for RANGE methods.
-                    data = _with_retries(api_method, date_str, date_str)
+                data = _with_retries(api_method, date_str)
 
                 if data:
                     saved_files.extend(
@@ -381,41 +381,174 @@ class GarminExtractor:
 
         return saved_files
 
+    def _extract_range(
+        self, data_type: GarminDataType, start_date: date, end_date: date
+    ) -> List[Path]:
+        """
+        Extract a RANGE-typed Garmin data type with ONE API call for the full window.
+
+        The Garmin endpoints behind RANGE-typed wrappers accept a native date range and
+        return all matching rows in one response. Calling them once per day with
+        ``start = end`` wastes API quota and multiplies disk I/O. Post-fetch, types
+        whose rows are naturally per-day (``BODY_COMPOSITION``, ``ACTIVITIES_LIST``)
+        are split into per-day files via
+        :meth:`_split_range_response_to_per_day_files`, preserving the downstream
+        ``(user, day)`` FileSet abstraction the processor depends on.
+
+        Failure isolation is per-range (one API call): a failure records
+        ``"{start}..{end}"`` in :attr:`failures`.
+
+        :param data_type: GarminDataType with RANGE time parameter.
+        :param start_date: Inclusive start date for the API call.
+        :param end_date: Inclusive end date for the API call.
+        :return: List of saved file paths (one per day for splittable types, one
+            stamped end_date for unsplittable RANGE types).
+        """
+        start_str = start_date.strftime("%Y-%m-%d")
+        end_str = end_date.strftime("%Y-%m-%d")
+        LOGGER.info(
+            f"Fetching {data_type.emoji} {data_type.name} data for "
+            f"{start_str}..{end_str} (single call)."
+        )
+
+        try:
+            api_method = getattr(self.garmin_client, data_type.api_method)
+            data = _with_retries(api_method, start_str, end_str)
+        except Exception as e:
+            LOGGER.error(
+                f"⚠️ {data_type.name} {start_str}..{end_str} failed: "
+                f"{type(e).__name__}: {e}.",
+                exc_info=True,
+            )
+            self.failures.append(
+                ExtractionFailure(
+                    user_id=self.user_id or "",
+                    data_type=data_type.name,
+                    date=f"{start_str}..{end_str}",
+                    activity_id="",
+                    error=f"{type(e).__name__}: {e}",
+                )
+            )
+            return []
+
+        if not data:
+            LOGGER.warning(
+                f"⚠️ {data_type.emoji} {data_type.name}: No data for "
+                f"{start_str}..{end_str}."
+            )
+            return []
+
+        if data_type.name in ("BODY_COMPOSITION", "ACTIVITIES_LIST"):
+            return self._split_range_response_to_per_day_files(
+                data, data_type, start_date, end_date
+            )
+
+        # Unsplittable RANGE types (a single-payload response that should not be
+        # split per day) get one file stamped end_date.
+        return self._save_garmin_data(data, data_type, end_date)
+
+    def _split_range_response_to_per_day_files(
+        self,
+        data: Union[Dict, List],
+        data_type: GarminDataType,
+        start_date: date,
+        end_date: date,
+    ) -> List[Path]:
+        """
+        Split a per-window RANGE response into one file per calendar date.
+
+        ``BODY_COMPOSITION``'s response is a dict with a ``dateWeightList`` key (each
+        entry has ``calendarDate``). ``ACTIVITIES_LIST``'s response is a list of
+        activity dicts (each has ``startTimeLocal`` whose date prefix is the local
+        calendar date). Days with no entries produce no file; the downstream FileSet
+        abstraction tolerates a ``(user, day)`` with no data.
+
+        :param data: Per-window response payload (dict for BODY_COMPOSITION, list for
+            ACTIVITIES_LIST).
+        :param data_type: BODY_COMPOSITION or ACTIVITIES_LIST data type.
+        :param start_date: Inclusive start date of the requested window.
+        :param end_date: Inclusive end date of the requested window.
+        :return: List of saved per-day file paths.
+        :raises ValueError: If ``data_type.name`` is not BODY_COMPOSITION or
+            ACTIVITIES_LIST.
+        """
+        if data_type.name == "BODY_COMPOSITION":
+            dict_buckets: Dict[date, dict] = {}
+            entries = (data or {}).get("dateWeightList") or []
+            for entry in entries:
+                cal_date_str = entry.get("calendarDate")
+                if not cal_date_str:
+                    continue
+                try:
+                    cal_date = date.fromisoformat(cal_date_str)
+                except ValueError:
+                    continue
+                if not (start_date <= cal_date <= end_date):
+                    continue
+                bucket = dict_buckets.setdefault(cal_date, {"dateWeightList": []})
+                bucket["dateWeightList"].append(entry)
+            buckets: Dict[date, Union[dict, list]] = dict_buckets
+        elif data_type.name == "ACTIVITIES_LIST":
+            list_buckets: Dict[date, list] = {}
+            for activity in data or []:
+                start_local = activity.get("startTimeLocal", "")
+                cal_date_str = start_local[:10]
+                try:
+                    cal_date = date.fromisoformat(cal_date_str)
+                except ValueError:
+                    continue
+                if not (start_date <= cal_date <= end_date):
+                    continue
+                list_buckets.setdefault(cal_date, []).append(activity)
+            buckets = list_buckets
+        else:
+            raise ValueError(
+                f"_split_range_response_to_per_day_files called with unsupported "
+                f"type: {data_type.name}."
+            )
+
+        saved: List[Path] = []
+        for cal_date, payload in sorted(buckets.items()):
+            saved.extend(self._save_garmin_data(payload, data_type, cal_date))
+        return saved
+
     def _extract_data_by_type(
         self, data_type: GarminDataType, start_date: date, end_date: date
     ) -> List[Path]:
         """
         Extract Garmin data for a specific type.
 
-        ACTIVITY files use different extraction logic.
-
-        Uses the appropriate API method, handling the associated API time parameter
-        pattern (DAILY, RANGE, NO_DATE) and generates consistent filenames.
+        Dispatches by ``api_method_time_param``: DAILY loops day-by-day, RANGE makes one
+        call covering the full requested window, NO_DATE makes one call with no date
+        parameters, PER_ACTIVITY is handled separately by :meth:`extract_fit_activities`
+        and short-circuits here.
 
         :param data_type: GarminDataType defining the extraction parameters.
         :param start_date: Start date for data extraction (inclusive).
         :param end_date: End date for data extraction (inclusive).
         :return: List of saved file paths.
+        :raises ValueError: If ``data_type.api_method_time_param`` is not one of the
+            four supported variants.
         """
-        # Special case: ACTIVITY and EXERCISE_SETS use different extraction logic.
-        if data_type.name in ("ACTIVITY", "EXERCISE_SETS"):
+        # PER_ACTIVITY types iterate per activity_id, not per date. They are
+        # downloaded by extract_fit_activities() after ACTIVITIES_LIST is fetched.
+        if data_type.api_method_time_param == APIMethodTimeParam.PER_ACTIVITY:
             LOGGER.info(
                 f"{data_type.emoji} {data_type.name} files will be handled separately "
                 f"by extract_fit_activities()."
             )
-            return []  # Return empty list, let extract_fit_activities() handle it.
+            return []
 
-        if data_type.api_method_time_param in [
-            APIMethodTimeParam.DAILY,
-            APIMethodTimeParam.RANGE,
-        ]:
-            # Process each day individually using common helper method.
+        if data_type.api_method_time_param == APIMethodTimeParam.DAILY:
             return self._extract_day_by_day(data_type, start_date, end_date)
+
+        if data_type.api_method_time_param == APIMethodTimeParam.RANGE:
+            return self._extract_range(data_type, start_date, end_date)
 
         if data_type.api_method_time_param == APIMethodTimeParam.NO_DATE:
             # Process no-date data. Wrap the call in _with_retries so
             # transient network failures absorb the same way they do for
-            # DAILY / RANGE types via _extract_day_by_day; otherwise NO_DATE
+            # DAILY (per-day) and RANGE (per-window) types; otherwise NO_DATE
             # types (USER_PROFILE, PERSONAL_RECORDS, RACE_PREDICTIONS) would
             # fail on the first DNS hiccup.
             LOGGER.info(f"{data_type.emoji} Fetching {data_type.name.lower()} data.")
@@ -436,7 +569,10 @@ class GarminExtractor:
         )
 
     def _save_garmin_data(
-        self, data: dict, data_type: GarminDataType, file_date: date
+        self,
+        data: Union[dict, list],
+        data_type: GarminDataType,
+        file_date: date,
     ) -> List[Path]:
         """
         Save Garmin data to JSON file with standardized naming.
@@ -444,7 +580,9 @@ class GarminExtractor:
         Generates filenames with user ID, data type, and ISO 8601 timestamp for
         consistent batching. Creates midday timestamp for date-based grouping.
 
-        :param data: The data to save.
+        :param data: The data to save. Most callers pass a dict (the typical Garmin
+            response shape); per-day ACTIVITIES_LIST splits pass a list of activity
+            dicts.
         :param data_type: The data type.
         :param file_date: Date for timestamp generation used in filename.
         :return: List of saved file paths.
@@ -471,15 +609,16 @@ class GarminExtractor:
         Read saved ACTIVITIES_LIST JSON files in the extractor's date window from
         ``ingest_dir`` and merge them into a single deduplicated activities list.
 
-        The registry-driven extract loop calls ``get_activities_by_date`` once per day
-        inside ``_extract_day_by_day`` (RANGE-typed), so a multi-day window writes one
-        ``<user_id>_ACTIVITIES_LIST_<timestamp>.json`` file per day. Only files whose
-        embedded date falls within ``[self.start_date, self.end_date]`` are merged:
-        leftover files from a previous failed run with a different window are ignored so
-        we don't download FIT files outside the requested interval. Entries are merged
-        by ``activityId`` (last value wins for duplicates); entries that are not dicts
-        or are missing ``activityId`` are dropped with a warning so downstream code can
-        assume every item is a well-formed activity.
+        The registry-driven extract loop calls ``get_activities_by_date`` once for the
+        full requested window inside ``_extract_range`` (RANGE-typed), then the per-day
+        splitter writes one ``<user_id>_ACTIVITIES_LIST_<timestamp>.json`` file per day
+        with activities. Only files whose embedded date falls within ``[self.start_date,
+        self.end_date]`` are merged: leftover files from a previous failed run with a
+        different window are ignored so we don't download FIT files outside the
+        requested interval. Entries are merged by ``activityId`` (last value wins for
+        duplicates); entries that are not dicts or are missing ``activityId`` are
+        dropped with a warning so downstream code can assume every item is a well-formed
+        activity.
 
         Falls back to ``None`` (caller hits the live API) on any read or parse error, OR
         when the on-disk files don't cover every day in ``[start_date, end_date]`` (a
@@ -605,9 +744,10 @@ class GarminExtractor:
 
         # Get list of activities. The registry-driven extract loop has
         # already fetched and saved this same data as ACTIVITIES_LIST JSON
-        # in ingest_dir (the API is RANGE-typed and called once per day).
-        # Read it from disk to avoid duplicate API calls. Fall back to a
-        # live API call if the file is missing or unreadable.
+        # in ingest_dir (the API is RANGE-typed and called once for the full
+        # window, then split into per-day files). Read it from disk to avoid
+        # duplicate API calls. Fall back to a live API call if the file is
+        # missing or unreadable.
         start_str = self.start_date.strftime("%Y-%m-%d")
         end_str = self.end_date.strftime("%Y-%m-%d")
 

--- a/dags/pipelines/garmin/extract.py
+++ b/dags/pipelines/garmin/extract.py
@@ -476,8 +476,11 @@ class GarminExtractor:
             dict_buckets: Dict[date, dict] = {}
             # Defensive: BODY_COMPOSITION's API contract is a dict wrapper, but if
             # an unexpected shape (list, string) ever reaches the splitter, fall
-            # back to "no entries" instead of raising on .get().
-            entries = data.get("dateWeightList") or [] if isinstance(data, dict) else []
+            # back to "no entries" instead of raising on .get(). Explicit parens
+            # to make the short-circuit intent unambiguous to readers.
+            entries = (
+                (data.get("dateWeightList") or []) if isinstance(data, dict) else []
+            )
             for entry in entries:
                 # Defensive: skip non-dict entries rather than raise on
                 # entry.get(...) below. Mirrors _load_activities_list_from_disk's

--- a/dags/pipelines/garmin/extract.py
+++ b/dags/pipelines/garmin/extract.py
@@ -431,20 +431,31 @@ class GarminExtractor:
             )
             return []
 
+        # Splittable RANGE types route to the splitter even on an empty payload
+        # (e.g. ACTIVITIES_LIST returning []), because the splitter writes a
+        # per-day empty-list file for ACTIVITIES_LIST so the on-disk coverage
+        # check used by extract_fit_activities trusts the cache. Only bail on
+        # None (transport-level "no response"), not on empty-but-valid data.
+        if data_type.name in ("BODY_COMPOSITION", "ACTIVITIES_LIST"):
+            if data is None:
+                LOGGER.warning(
+                    f"⚠️ {data_type.emoji} {data_type.name}: No data for "
+                    f"{start_str}..{end_str}."
+                )
+                return []
+            return self._split_range_response_to_per_day_files(
+                data, data_type, start_date, end_date
+            )
+
+        # Unsplittable RANGE types (a single-payload response that should not be
+        # split per day) skip on any falsy payload and otherwise get one file
+        # stamped end_date.
         if not data:
             LOGGER.warning(
                 f"⚠️ {data_type.emoji} {data_type.name}: No data for "
                 f"{start_str}..{end_str}."
             )
             return []
-
-        if data_type.name in ("BODY_COMPOSITION", "ACTIVITIES_LIST"):
-            return self._split_range_response_to_per_day_files(
-                data, data_type, start_date, end_date
-            )
-
-        # Unsplittable RANGE types (a single-payload response that should not be
-        # split per day) get one file stamped end_date.
         return self._save_garmin_data(data, data_type, end_date)
 
     def _split_range_response_to_per_day_files(
@@ -455,13 +466,19 @@ class GarminExtractor:
         end_date: date,
     ) -> List[Path]:
         """
-        Split a per-window RANGE response into one file per calendar date.
+        Split a per-window RANGE response into per-day files.
 
         ``BODY_COMPOSITION``'s response is a dict with a ``dateWeightList`` key (each
-        entry has ``calendarDate``). ``ACTIVITIES_LIST``'s response is a list of
-        activity dicts (each has ``startTimeLocal`` whose date prefix is the local
-        calendar date). Days with no entries produce no file; the downstream FileSet
-        abstraction tolerates a ``(user, day)`` with no data.
+        entry has ``calendarDate``); the splitter is sparse — days with no weigh-in
+        produce no file (the FileSet abstraction tolerates a ``(user, day)`` with no
+        data).
+
+        ``ACTIVITIES_LIST``'s response is a list of activity dicts (each has
+        ``startTimeLocal`` whose date prefix is the local calendar date); the splitter
+        is dense — every day in ``[start_date, end_date]`` produces a file, with an
+        empty list ``[]`` for days that have no activities. This density is required by
+        :meth:`_load_activities_list_from_disk`'s on-disk coverage check: without a file
+        per day, the FIT downloader would fall back to a redundant live API call.
 
         :param data: Per-window response payload (dict for BODY_COMPOSITION, list for
             ACTIVITIES_LIST).
@@ -636,8 +653,10 @@ class GarminExtractor:
 
         The registry-driven extract loop calls ``get_activities_by_date`` once for the
         full requested window inside ``_extract_range`` (RANGE-typed), then the per-day
-        splitter writes one ``<user_id>_ACTIVITIES_LIST_<timestamp>.json`` file per day
-        with activities. Only files whose embedded date falls within ``[self.start_date,
+        splitter writes one ``<user_id>_ACTIVITIES_LIST_<timestamp>.json`` file for
+        every day in the window — non-empty for days with activities, an empty list
+        ``[]`` for days without — so the on-disk coverage check below sees one file per
+        requested day. Only files whose embedded date falls within ``[self.start_date,
         self.end_date]`` are merged: leftover files from a previous failed run with a
         different window are ignored so we don't download FIT files outside the
         requested interval. Entries are merged by ``activityId`` (last value wins for

--- a/dags/pipelines/garmin/extract.py
+++ b/dags/pipelines/garmin/extract.py
@@ -476,6 +476,11 @@ class GarminExtractor:
             dict_buckets: Dict[date, dict] = {}
             entries = (data or {}).get("dateWeightList") or []
             for entry in entries:
+                # Defensive: skip non-dict entries rather than raise on
+                # entry.get(...) below. Mirrors _load_activities_list_from_disk's
+                # tolerance for malformed payloads.
+                if not isinstance(entry, dict):
+                    continue
                 cal_date_str = entry.get("calendarDate")
                 if not cal_date_str:
                     continue
@@ -491,6 +496,11 @@ class GarminExtractor:
         elif data_type.name == "ACTIVITIES_LIST":
             list_buckets: Dict[date, list] = {}
             for activity in data or []:
+                # Defensive: skip non-dict entries (e.g. unexpected wrapper
+                # shapes) rather than raise on activity.get(...). Mirrors
+                # _load_activities_list_from_disk's tolerance.
+                if not isinstance(activity, dict):
+                    continue
                 start_local = activity.get("startTimeLocal", "")
                 cal_date_str = start_local[:10]
                 try:

--- a/dags/pipelines/garmin/extract.py
+++ b/dags/pipelines/garmin/extract.py
@@ -474,7 +474,10 @@ class GarminExtractor:
         """
         if data_type.name == "BODY_COMPOSITION":
             dict_buckets: Dict[date, dict] = {}
-            entries = (data or {}).get("dateWeightList") or []
+            # Defensive: BODY_COMPOSITION's API contract is a dict wrapper, but if
+            # an unexpected shape (list, string) ever reaches the splitter, fall
+            # back to "no entries" instead of raising on .get().
+            entries = data.get("dateWeightList") or [] if isinstance(data, dict) else []
             for entry in entries:
                 # Defensive: skip non-dict entries rather than raise on
                 # entry.get(...) below. Mirrors _load_activities_list_from_disk's

--- a/dags/pipelines/garmin/extract.py
+++ b/dags/pipelines/garmin/extract.py
@@ -500,7 +500,16 @@ class GarminExtractor:
                 bucket["dateWeightList"].append(entry)
             buckets: Dict[date, Union[dict, list]] = dict_buckets
         elif data_type.name == "ACTIVITIES_LIST":
-            list_buckets: Dict[date, list] = {}
+            # Pre-populate every day in the window with an empty list so days
+            # without activities still produce a (zero-byte-list) file.
+            # _load_activities_list_from_disk requires one file per day to
+            # trust the on-disk cache and skip a second API call in
+            # extract_fit_activities. Without this, any zero-activity day in
+            # the window would force the FIT downloader to re-hit the API.
+            list_buckets: Dict[date, list] = {
+                start_date + timedelta(days=i): []
+                for i in range((end_date - start_date).days + 1)
+            }
             for activity in data or []:
                 # Defensive: skip non-dict entries (e.g. unexpected wrapper
                 # shapes) rather than raise on activity.get(...). Mirrors
@@ -515,7 +524,7 @@ class GarminExtractor:
                     continue
                 if not (start_date <= cal_date <= end_date):
                     continue
-                list_buckets.setdefault(cal_date, []).append(activity)
+                list_buckets[cal_date].append(activity)
             buckets = list_buckets
         else:
             raise ValueError(

--- a/dags/pipelines/garmin/garmin_client/api.py
+++ b/dags/pipelines/garmin/garmin_client/api.py
@@ -368,10 +368,16 @@ def get_menstrual_calendar_data(
         # chunk as if it produced no data and continue.
         if isinstance(result, dict):
             got_response = True
-            for cycle in result.get("cycleSummaries") or []:
-                cycle_start = cycle.get("startDate")
-                if cycle_start:
-                    cycles_by_start[cycle_start] = cycle
+            cycle_summaries = result.get("cycleSummaries") or []
+            # Defensive: cycleSummaries should be a list of dicts; skip
+            # malformed entries rather than raise on cycle.get(...).
+            if isinstance(cycle_summaries, list):
+                for cycle in cycle_summaries:
+                    if not isinstance(cycle, dict):
+                        continue
+                    cycle_start = cycle.get("startDate")
+                    if cycle_start:
+                        cycles_by_start[cycle_start] = cycle
             logged_symptom.update(result.get("loggedSymptomDays") or [])
             logged_ovulation.update(result.get("loggedOvulationDays") or [])
             logged_note.update(result.get("loggedNoteDays") or [])

--- a/dags/pipelines/garmin/garmin_client/api.py
+++ b/dags/pipelines/garmin/garmin_client/api.py
@@ -264,7 +264,11 @@ def get_menstrual_data_for_date(
     cdate = _validate_date_format(cdate, "cdate")
     url = f"{MENSTRUAL_DAYVIEW_URL}/{cdate}"
     result = client._connectapi(url)
-    if result and (result.get("daySummary") or result.get("dayLog")):
+    # Defensive: if the endpoint ever returns a non-dict payload (list, string,
+    # error page), don't crash on result.get(...). Treat as no data.
+    if not isinstance(result, dict):
+        return None
+    if result.get("daySummary") or result.get("dayLog"):
         return result
     return None
 
@@ -358,7 +362,11 @@ def get_menstrual_calendar_data(
             f"{chunk_start.isoformat()}/{chunk_end.isoformat()}"
         )
         result = client._connectapi(url)
-        if result is not None:
+        # Defensive: only merge if the chunk response is a dict. A non-dict
+        # payload (transient error page, unexpected upstream change) on one
+        # chunk should not abort the whole multi-chunk range — treat that
+        # chunk as if it produced no data and continue.
+        if isinstance(result, dict):
             got_response = True
             for cycle in result.get("cycleSummaries") or []:
                 cycle_start = cycle.get("startDate")

--- a/dags/pipelines/garmin/garmin_client/api.py
+++ b/dags/pipelines/garmin/garmin_client/api.py
@@ -378,9 +378,18 @@ def get_menstrual_calendar_data(
                     cycle_start = cycle.get("startDate")
                     if cycle_start:
                         cycles_by_start[cycle_start] = cycle
-            logged_symptom.update(result.get("loggedSymptomDays") or [])
-            logged_ovulation.update(result.get("loggedOvulationDays") or [])
-            logged_note.update(result.get("loggedNoteDays") or [])
+            # Defensive: only merge if the value is a list. set.update over a
+            # string would add one character per iteration, corrupting the
+            # merged day list. Garmin's contract is a list of date strings;
+            # anything else is treated as no data for that field.
+            for key, accum in (
+                ("loggedSymptomDays", logged_symptom),
+                ("loggedOvulationDays", logged_ovulation),
+                ("loggedNoteDays", logged_note),
+            ):
+                value = result.get(key)
+                if isinstance(value, list):
+                    accum.update(value)
         chunk_start = chunk_end + timedelta(days=1)
 
     if not got_response:

--- a/dags/pipelines/garmin/garmin_client/api.py
+++ b/dags/pipelines/garmin/garmin_client/api.py
@@ -1,7 +1,7 @@
 """
 API method implementations for the vendored Garmin Connect client.
 
-Each function here corresponds to one of the 16 Garmin Connect endpoints the
+Each function here corresponds to one of the Garmin Connect endpoints the
 openetl pipeline consumes. The functions are written as plain functions taking
 the ``GarminClient`` instance as their first argument so that the client class
 can stay slim, and so that the file is testable in isolation.
@@ -9,18 +9,19 @@ can stay slim, and so that the file is testable in isolation.
 Method-to-endpoint mapping is inherited from the upstream ``python-garminconnect``
 library; URL templates live in :mod:`.constants`.
 
-The 16 supported endpoints:
+The supported endpoints:
 
 - Daily wellness:        sleep, stress, respiration, heart_rates, training_readiness,
-                         training_status, steps, floors, intensity_minutes
+                         training_status, steps, floors, intensity_minutes,
+                         menstrual_cycle_dayview
 - Range data:            activities_by_date (paginated), activity_exercise_sets,
-                         body_composition
+                         body_composition, menstrual_cycle_calendar (paginated)
 - No-date metadata:      personal_records, race_predictions, user_profile
 - Binary download:       download_activity (FIT/TCX/GPX/KML/CSV)
 """
 
 import re
-from datetime import datetime
+from datetime import datetime, timedelta
 from enum import Enum, auto
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
@@ -37,6 +38,9 @@ from .constants import (
     GPX_DOWNLOAD_URL,
     HEART_RATES_DAILY_URL,
     KML_DOWNLOAD_URL,
+    MENSTRUAL_CALENDAR_MAX_DAYS,
+    MENSTRUAL_CALENDAR_URL,
+    MENSTRUAL_DAYVIEW_URL,
     PERSONAL_RECORD_URL,
     RACE_PREDICTOR_URL,
     TCX_DOWNLOAD_URL,
@@ -233,6 +237,38 @@ def get_intensity_minutes_data(client: "GarminClient", cdate: str) -> Dict[str, 
     return client._connectapi(url)
 
 
+def get_menstrual_data_for_date(
+    client: "GarminClient", cdate: str
+) -> Optional[Dict[str, Any]]:
+    """
+    Fetch menstrual cycle dayview data for the given date.
+
+    The dayview endpoint returns the per-day cycle state (phase, day-in-cycle, predicted
+    cycle length) wrapped in ``daySummary`` plus the user's logged data (symptoms,
+    moods, discharge, flow, sex drive, sexual activity, notes, ovulation/baby-movement
+    flags) wrapped in ``dayLog``. Days inside a predicted-cycle window return
+    ``daySummary`` populated and ``dayLog: null``; days outside every cycle window
+    return a bare ``{}``.
+
+    Returns ``None`` when neither ``daySummary`` nor ``dayLog`` is present. The
+    extractor's ``if data:`` check already drops a bare ``{}`` (it's falsy), but this
+    wrapper additionally drops *truthy* response shapes that lack the expected keys
+    (e.g. an unexpected wrapper-only dict) so the extractor never persists meaningless
+    payloads to disk.
+
+    :param client: GarminClient instance.
+    :param cdate: Date in ``YYYY-MM-DD`` format.
+    :return: Menstrual cycle dictionary with ``daySummary`` and ``dayLog`` keys, or
+        ``None`` when no cycle data exists for the date.
+    """
+    cdate = _validate_date_format(cdate, "cdate")
+    url = f"{MENSTRUAL_DAYVIEW_URL}/{cdate}"
+    result = client._connectapi(url)
+    if result and (result.get("daySummary") or result.get("dayLog")):
+        return result
+    return None
+
+
 def get_body_composition(
     client: "GarminClient", startdate: str, enddate: Optional[str] = None
 ) -> Optional[Dict[str, Any]]:
@@ -265,6 +301,83 @@ def get_body_composition(
     if result and result.get("dateWeightList"):
         return result
     return None
+
+
+def get_menstrual_calendar_data(
+    client: "GarminClient", startdate: str, enddate: Optional[str] = None
+) -> Optional[Dict[str, Any]]:
+    """
+    Fetch menstrual cycle summaries (observed and predicted) for a date range.
+
+    The Garmin calendar endpoint enforces a hard ``MENSTRUAL_CALENDAR_MAX_DAYS``
+    (92-day) max range per request. This wrapper chunks longer ranges into contiguous
+    sub-windows, calls the endpoint once per chunk, and merges results. Duplicate
+    ``cycleSummaries`` entries (a single cycle may appear in adjacent chunks) are
+    deduped by ``startDate`` (the later chunk's view wins, so the freshest projection is
+    kept); ``loggedSymptomDays`` / ``loggedOvulationDays`` / ``loggedNoteDays`` are
+    merged into sorted unique lists.
+
+    Returns ``None`` only when no chunk produced a response (e.g. transport failure on
+    every chunk). A successful response with zero cycles still returns the merged shape
+    with empty arrays so the file lands and ``_process_menstrual_cycle_summary`` can
+    fire its wipe-and-replace policy for stale predicted rows. Without this, a user who
+    stopped tracking cycles (or never had any in the queried window) would leave
+    previously-extracted predicted rows stranded in the database.
+
+    :param client: GarminClient instance.
+    :param startdate: Range start (``YYYY-MM-DD``, inclusive).
+    :param enddate: Range end (``YYYY-MM-DD``, inclusive). Defaults to ``startdate``.
+    :return: Merged calendar dictionary (possibly with empty arrays), or ``None`` when
+        no chunk in the range produced a response.
+    """
+    startdate = _validate_date_format(startdate, "startdate")
+    if enddate is None:
+        enddate = startdate
+    else:
+        enddate = _validate_date_format(enddate, "enddate")
+
+    start = datetime.strptime(startdate, _DATE_FORMAT_STR).date()
+    end = datetime.strptime(enddate, _DATE_FORMAT_STR).date()
+    if end < start:
+        raise ValueError(
+            f"enddate ({enddate}) must be on or after startdate ({startdate})"
+        )
+
+    chunk_step = timedelta(days=MENSTRUAL_CALENDAR_MAX_DAYS - 1)
+    cycles_by_start: Dict[str, Dict[str, Any]] = {}
+    logged_symptom: set = set()
+    logged_ovulation: set = set()
+    logged_note: set = set()
+    got_response = False
+
+    chunk_start = start
+    while chunk_start <= end:
+        chunk_end = min(chunk_start + chunk_step, end)
+        url = (
+            f"{MENSTRUAL_CALENDAR_URL}/"
+            f"{chunk_start.isoformat()}/{chunk_end.isoformat()}"
+        )
+        result = client._connectapi(url)
+        if result is not None:
+            got_response = True
+            for cycle in result.get("cycleSummaries") or []:
+                cycle_start = cycle.get("startDate")
+                if cycle_start:
+                    cycles_by_start[cycle_start] = cycle
+            logged_symptom.update(result.get("loggedSymptomDays") or [])
+            logged_ovulation.update(result.get("loggedOvulationDays") or [])
+            logged_note.update(result.get("loggedNoteDays") or [])
+        chunk_start = chunk_end + timedelta(days=1)
+
+    if not got_response:
+        return None
+
+    return {
+        "cycleSummaries": [cycles_by_start[k] for k in sorted(cycles_by_start)],
+        "loggedSymptomDays": sorted(logged_symptom),
+        "loggedOvulationDays": sorted(logged_ovulation),
+        "loggedNoteDays": sorted(logged_note),
+    }
 
 
 # ----------------------------------------------------------------------------------------

--- a/dags/pipelines/garmin/garmin_client/client.py
+++ b/dags/pipelines/garmin/garmin_client/client.py
@@ -885,6 +885,12 @@ class GarminClient:
         """
         return api.get_intensity_minutes_data(self, cdate)
 
+    def get_menstrual_data_for_date(self, cdate: str) -> Optional[Dict[str, Any]]:
+        """
+        See :func:`api.get_menstrual_data_for_date`.
+        """
+        return api.get_menstrual_data_for_date(self, cdate)
+
     def get_body_composition(
         self, startdate: str, enddate: Optional[str] = None
     ) -> Dict[str, Any]:
@@ -892,6 +898,14 @@ class GarminClient:
         See :func:`api.get_body_composition`.
         """
         return api.get_body_composition(self, startdate, enddate)
+
+    def get_menstrual_calendar_data(
+        self, startdate: str, enddate: Optional[str] = None
+    ) -> Optional[Dict[str, Any]]:
+        """
+        See :func:`api.get_menstrual_calendar_data`.
+        """
+        return api.get_menstrual_calendar_data(self, startdate, enddate)
 
     def get_activities_by_date(
         self,

--- a/dags/pipelines/garmin/garmin_client/constants.py
+++ b/dags/pipelines/garmin/garmin_client/constants.py
@@ -122,6 +122,12 @@ RACE_PREDICTOR_URL = "/metrics-service/metrics/racepredictions"
 # Personal records.
 PERSONAL_RECORD_URL = "/personalrecord-service/personalrecord/prs"
 
+# Periodic health (menstrual cycle). Calendar enforces a hard 92-day max range
+# per request; the API wrapper paginates internally for longer windows.
+MENSTRUAL_DAYVIEW_URL = "/periodichealth-service/menstrualcycle/dayview"
+MENSTRUAL_CALENDAR_URL = "/periodichealth-service/menstrualcycle/calendar"
+MENSTRUAL_CALENDAR_MAX_DAYS = 92
+
 # Activities.
 ACTIVITIES_URL = "/activitylist-service/activities/search/activities"
 ACTIVITY_URL = "/activity-service/activity"

--- a/dags/pipelines/garmin/process.py
+++ b/dags/pipelines/garmin/process.py
@@ -104,6 +104,14 @@ class GarminProcessor(Processor):
         :param file_set: FileSet containing Garmin data files to process.
         :param session: SQLAlchemy Session object.
         """
+        # Reset per-FileSet coordination state. _skipped_activity_ids is scoped
+        # to a single FileSet (the ACTIVITIES_LIST processor populates it and
+        # the per-activity child processors consume it within the same
+        # process_file_set call). A GarminProcessor instance is reused across
+        # FileSets in a single batch, so without this reset the set would leak
+        # ids across unrelated days and grow unbounded over long runs.
+        self._skipped_activity_ids = set()
+
         # Extract `user_id` from the first file and set instance attribute.
         # All files in a file set have same `user_id` and `timestamp`.
         first_file = file_set.file_paths[0]

--- a/dags/pipelines/garmin/process.py
+++ b/dags/pipelines/garmin/process.py
@@ -2541,7 +2541,10 @@ class GarminProcessor(Processor):
                     user_id=int(self.user_id),
                     start_date=datetime.strptime(start_date_str, "%Y-%m-%d").date(),
                     period_length=cycle.get("periodLength"),
-                    predicted_cycle=bool(cycle.get("predictedCycle", False)),
+                    # `is True` accepts only the literal bool: a string like
+                    # "false" or any non-bool corrupted payload defaults to
+                    # False instead of being silently truthy-cast.
+                    predicted_cycle=cycle.get("predictedCycle") is True,
                 )
             )
 

--- a/dags/pipelines/garmin/process.py
+++ b/dags/pipelines/garmin/process.py
@@ -2521,6 +2521,14 @@ class GarminProcessor(Processor):
 
         records: List[MenstrualCycleSummary] = []
         for cycle in cycle_summaries:
+            # Defensive: each cycle entry should be a dict. Skip malformed
+            # entries (non-dicts) rather than raise on cycle.get(...).
+            if not isinstance(cycle, dict):
+                LOGGER.warning(
+                    f"⚠️ Skipping non-dict cycle summary entry in "
+                    f"{file_path.name}: {cycle!r}."
+                )
+                continue
             start_date_str = cycle.get("startDate")
             if not start_date_str:
                 LOGGER.warning(

--- a/dags/pipelines/garmin/process.py
+++ b/dags/pipelines/garmin/process.py
@@ -26,6 +26,7 @@ from dags.pipelines.garmin.constants import (
     GARMIN_DATA_REGISTRY,
     PR_TYPE_LABELS,
     SEMICIRCLES_TO_DEGREES,
+    MenstrualCyclePhase,
     SleepStage,
 )
 from dags.pipelines.garmin.sqla_models import (
@@ -43,6 +44,9 @@ from dags.pipelines.garmin.sqla_models import (
     HeartRate,
     HRV,
     IntensityMinutes,
+    MenstrualCycleDay,
+    MenstrualCycleSummary,
+    MenstrualCycleTag,
     PersonalRecord,
     RacePredictions,
     Respiration,
@@ -130,6 +134,8 @@ class GarminProcessor(Processor):
                 ("FLOORS", self._process_floors),
                 ("HEART_RATE", self._process_heart_rate),
                 ("INTENSITY_MINUTES", self._process_intensity_minutes),
+                ("MENSTRUAL_CYCLE_DAY", self._process_menstrual_cycle_day),
+                ("MENSTRUAL_CYCLE_SUMMARY", self._process_menstrual_cycle_summary),
                 ("PERSONAL_RECORDS", self._process_personal_records),
                 ("RACE_PREDICTIONS", self._process_race_predictions),
                 ("RESPIRATION", self._process_respiration),
@@ -2319,6 +2325,211 @@ class GarminProcessor(Processor):
             LOGGER.info(f"Processed {len(floors_records)} floors records.")
         else:
             LOGGER.warning("⚠️ No floors data found.")
+
+    def _process_menstrual_cycle_day(self, file_path: Path, session: Session) -> None:
+        """
+        Process a MENSTRUAL_CYCLE_DAY file containing one day's cycle log.
+
+        Upserts the day row keyed by ``(user_id, date)``. Then runs delete-then-insert
+        for that day's tags (symptoms, moods, discharge) so user removals propagate on
+        reprocess. The integer ``daySummary.currentPhase`` is translated to a textual
+        label via :class:`MenstrualCyclePhase` and stored denormalized in
+        ``current_phase``; the integer index is not persisted.
+
+        :param file_path: Path to the MENSTRUAL_CYCLE_DAY JSON file.
+        :param session: SQLAlchemy Session object.
+        """
+        payload = self._load_json_file(file_path)
+        day_summary = payload.get("daySummary") or {}
+        day_log = payload.get("dayLog") or {}
+
+        # Recover the data date. Prefer dayLog.calendarDate; fall back to the
+        # filename timestamp (a midday UTC stamp built from the queried date).
+        date_str = day_log.get("calendarDate")
+        if not date_str:
+            ts_str = self._parse_filename(file_path.name)["timestamp"]
+            date_str = ts_str.split("T", 1)[0]
+        day_date = datetime.strptime(date_str, "%Y-%m-%d").date()
+
+        # Translate the numeric phase to a denormalized text label.
+        phase_int = day_summary.get("currentPhase")
+        current_phase_label: Optional[str] = None
+        if phase_int is not None:
+            try:
+                current_phase_label = MenstrualCyclePhase(phase_int).name
+            except ValueError:
+                LOGGER.warning(
+                    f"⚠️ Unknown menstrual cycle phase code {phase_int!r} in "
+                    f"{file_path.name}; storing as 'UNKNOWN_{phase_int}'."
+                )
+                current_phase_label = f"UNKNOWN_{phase_int}"
+
+        # Parse cycle start date (may be missing for fully-unlogged days).
+        cycle_start_str = day_summary.get("startDate")
+        cycle_start_date = (
+            datetime.strptime(cycle_start_str, "%Y-%m-%d").date()
+            if cycle_start_str
+            else None
+        )
+
+        # Parse the user's last-edit timestamp. Garmin returns ISO 8601 with a
+        # single-digit fractional second (e.g. "2026-05-25T18:34:49.9"), which
+        # Python 3.11+ fromisoformat accepts directly.
+        report_ts_str = day_log.get("reportTimestamp")
+        report_ts: Optional[datetime] = None
+        if report_ts_str:
+            # Strip a trailing "Z" so fromisoformat parses it under any Python
+            # version, then tag as UTC.
+            iso_str = report_ts_str.rstrip("Z")
+            parsed = datetime.fromisoformat(iso_str)
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=timezone.utc)
+            report_ts = parsed
+
+        day_record = MenstrualCycleDay(
+            user_id=int(self.user_id),
+            date=day_date,
+            cycle_start_date=cycle_start_date,
+            day_in_cycle=day_summary.get("dayInCycle"),
+            period_length=day_summary.get("periodLength"),
+            current_phase=current_phase_label,
+            length_of_current_phase=day_summary.get("lengthOfCurrentPhase"),
+            days_until_next_phase=day_summary.get("daysUntilNextPhase"),
+            predicted_cycle_length=day_summary.get("predictedCycleLength"),
+            cycle_type=day_summary.get("cycleType"),
+            predicted_cycle=day_summary.get("predictedCycle"),
+            flow=day_log.get("flow"),
+            sex_drive=day_log.get("sexDrive"),
+            sexual_activity=day_log.get("sexualActivity"),
+            notes=day_log.get("notes"),
+            report_ts=report_ts,
+            has_baby_movement=day_log.get("hasBabyMovement"),
+            ovulation_day=day_log.get("ovulationDay"),
+        )
+        upsert_model_instances(
+            session=session,
+            model_instances=[day_record],
+            conflict_columns=["user_id", "date"],
+            on_conflict_update=True,
+        )
+
+        # Delete-then-insert per (user_id, date) for all three tag kinds. This is the
+        # only safe pattern because users can REMOVE tags between extracts; a pure
+        # upsert-by-PK would leave orphan rows for removed tags. One DELETE clears
+        # symptoms, moods, and discharge together; one INSERT batch repopulates them.
+        session.execute(
+            delete(MenstrualCycleTag).where(
+                and_(
+                    MenstrualCycleTag.user_id == int(self.user_id),
+                    MenstrualCycleTag.date == day_date,
+                )
+            )
+        )
+
+        # Garmin currently returns each tag list as a flat list of string enums
+        # (e.g. ['BACKACHE', 'CRAMPS']). If a future Garmin change enriches the
+        # shape (e.g. {'name': 'CRAMPS', 'severity': 'MILD'}), skip non-string
+        # entries with a warning rather than silently stringifying the dict into
+        # the `name` column.
+        tag_records: List[MenstrualCycleTag] = []
+        for kind, names in (
+            ("SYMPTOM", day_log.get("symptoms") or []),
+            ("MOOD", day_log.get("moods") or []),
+            ("DISCHARGE", day_log.get("discharge") or []),
+        ):
+            for name in names:
+                if not name:
+                    continue
+                if not isinstance(name, str):
+                    LOGGER.warning(
+                        f"⚠️ Skipping non-string {kind} tag in "
+                        f"{file_path.name}: {name!r}."
+                    )
+                    continue
+                tag_records.append(
+                    MenstrualCycleTag(
+                        user_id=int(self.user_id),
+                        date=day_date,
+                        kind=kind,
+                        name=name,
+                    )
+                )
+
+        if tag_records:
+            session.add_all(tag_records)
+
+        LOGGER.info(
+            f"Processed menstrual cycle day for {day_date} "
+            f"({len(tag_records)} tags)."
+        )
+
+    def _process_menstrual_cycle_summary(
+        self, file_path: Path, session: Session
+    ) -> None:
+        """
+        Process a MENSTRUAL_CYCLE_SUMMARY file from the calendar endpoint.
+
+        Wipes all ``predicted_cycle=True`` rows for the current user before inserting
+        the new payload. Real (user-logged) cycles use upsert by ``(user_id,
+        start_date)`` because their start date is anchored to an observed event and does
+        not drift between extracts. Predictions, by contrast, shift dates as Garmin
+        recomputes projections, so wipe-and-replace is the only way to keep the table
+        mirroring the current Garmin state without accumulating stale predicted rows.
+
+        :param file_path: Path to the MENSTRUAL_CYCLE_SUMMARY JSON file.
+        :param session: SQLAlchemy Session object.
+        """
+        payload = self._load_json_file(file_path)
+        cycle_summaries = payload.get("cycleSummaries") or []
+
+        # Wipe stale predictions before insert so the table reflects Garmin's
+        # current projection set rather than the union of every past projection.
+        wipe_result = session.execute(
+            delete(MenstrualCycleSummary).where(
+                and_(
+                    MenstrualCycleSummary.user_id == int(self.user_id),
+                    MenstrualCycleSummary.predicted_cycle.is_(True),
+                )
+            )
+        )
+        wiped_predicted = wipe_result.rowcount or 0
+
+        if not cycle_summaries:
+            LOGGER.info(
+                f"No cycle summaries in {file_path.name}; "
+                f"wiped {wiped_predicted} stale predicted row(s)."
+            )
+            return
+
+        records: List[MenstrualCycleSummary] = []
+        for cycle in cycle_summaries:
+            start_date_str = cycle.get("startDate")
+            if not start_date_str:
+                LOGGER.warning(
+                    f"⚠️ Skipping cycle summary entry with no startDate in "
+                    f"{file_path.name}: {cycle}."
+                )
+                continue
+            records.append(
+                MenstrualCycleSummary(
+                    user_id=int(self.user_id),
+                    start_date=datetime.strptime(start_date_str, "%Y-%m-%d").date(),
+                    period_length=cycle.get("periodLength"),
+                    predicted_cycle=bool(cycle.get("predictedCycle", False)),
+                )
+            )
+
+        if records:
+            upsert_model_instances(
+                session=session,
+                model_instances=records,
+                conflict_columns=["user_id", "start_date"],
+                on_conflict_update=True,
+            )
+            LOGGER.info(
+                f"Processed {len(records)} menstrual cycle summary record(s); "
+                f"wiped {wiped_predicted} stale predicted row(s) first."
+            )
 
     def _process_personal_records(self, file_path: Path, session: Session):
         """

--- a/dags/pipelines/garmin/process.py
+++ b/dags/pipelines/garmin/process.py
@@ -82,6 +82,13 @@ class GarminProcessor(Processor):
         super().__init__(*args, **kwargs)
         self.user_id = None
         self.must_update_user = False
+        # Activity IDs the per-activity processors should skip because the
+        # ACTIVITIES_LIST processor already determined they're duplicates of
+        # another activity sharing the same (user_id, start_ts). Their parent
+        # row was never inserted, so trying to write child rows (FIT
+        # time-series, splits, laps, GPS path, EXERCISE_SETS) would FK-fail
+        # and quarantine the whole FileSet. See garmin-health-data#67.
+        self._skipped_activity_ids: set = set()
 
     def process_file_set(self, file_set: FileSet, session: Session):
         """
@@ -411,7 +418,7 @@ class GarminProcessor(Processor):
 
     def _process_activity_base(
         self, activity_data: Dict[str, Any], session: Session
-    ) -> int:
+    ) -> Optional[int]:
         """
         Extract activity fields and process to database using upsert with composite
         primary key.
@@ -419,9 +426,15 @@ class GarminProcessor(Processor):
         Uses pop() to remove processed fields from activity_data, enabling automatic
         supplemental metrics extraction without hardcoded exclusion lists.
 
+        Returns ``None`` when the activity is skipped (empty record, or a duplicate
+        ``(user_id, start_ts)`` collision with an existing activity in the database).
+        The caller treats ``None`` as "skip the rest of the per-activity pipeline" so
+        sport-specific aggregates and supplemental metrics are not attached to a non-
+        existent parent row.
+
         :param activity_data: Activity data from JSON (will be modified by pop()).
         :param session: SQLAlchemy Session object.
-        :return: Activity ID from the processed record.
+        :return: Activity ID from the processed record, or ``None`` if skipped.
         """
         # Extract activity ID.
         activity_id = activity_data.pop("activityId")
@@ -448,6 +461,44 @@ class GarminProcessor(Processor):
             tzinfo=timezone.utc
         )
         end_ts = datetime.fromisoformat(end_time_gmt_str).replace(tzinfo=timezone.utc)
+
+        # Activity-level deduplication. The `activity` table has a
+        # UNIQUE (user_id, start_ts) constraint expressing the real-world
+        # invariant "one user, one activity at any given instant" (a sensible
+        # guard against accidental upserts). Garmin Connect, however, does not
+        # itself enforce this: users can create multiple activities with the
+        # same start_ts (e.g. manually entering the same workout twice, or
+        # uploading from two devices that recorded the same session). When
+        # that happens the API returns both as distinct activity_ids and a
+        # naive upsert keyed on the PK would raise IntegrityError on the
+        # secondary UNIQUE constraint, quarantining the entire (user, day)
+        # FileSet - losing sleep, HR, stress, and everything else for that
+        # day. Detect the conflict and skip the duplicate with a warning so
+        # the rest of the day's data still loads. The first-seen activity for
+        # that start_ts wins; subsequent duplicates are dropped. The user can
+        # resolve the underlying duplication by deleting one entry in Garmin
+        # Connect.
+        existing_dup = session.execute(
+            select(Activity.activity_id).where(
+                Activity.user_id == int(self.user_id),
+                Activity.start_ts == start_ts,
+                Activity.activity_id != activity_id,
+            )
+        ).scalar_one_or_none()
+        if existing_dup is not None:
+            LOGGER.warning(
+                f"⚠️ Skipping duplicate activity {activity_id} for user "
+                f"{self.user_id}: another activity (activity_id={existing_dup}) "
+                f"already exists with start_ts={start_ts}. This usually means "
+                f"the same workout was entered twice (e.g. a manual entry "
+                f"created twice by accident). Delete one in Garmin Connect to "
+                f"clean it up."
+            )
+            # Remember this id so the per-activity-file processors (FIT,
+            # EXERCISE_SETS) downstream in the same FileSet also skip cleanly
+            # rather than FK-failing on the missing parent row.
+            self._skipped_activity_ids.add(activity_id)
+            return None
 
         # Calculate timezone offset in hours (decimal precision for half-hour zones).
         utc_naive = datetime.fromisoformat(start_time_gmt_str)
@@ -864,6 +915,17 @@ class GarminProcessor(Processor):
 
         if not activity_id:
             LOGGER.warning(f"⚠️ No activityId in {file_path.name}.")
+            return
+
+        # Skip if the parent activity was deduped (garmin-health-data#67):
+        # the activity row was never inserted, so writing child rows
+        # referencing it would FK-fail and quarantine the FileSet.
+        if int(activity_id) in self._skipped_activity_ids:
+            LOGGER.warning(
+                f"⚠️ Skipping EXERCISE_SETS for activity {activity_id} in "
+                f"{file_path.name}: parent activity was deduped (duplicate "
+                f"(user_id, start_ts))."
+            )
             return
 
         # Always delete existing rows for reprocessing (cleans stale data even
@@ -2474,6 +2536,17 @@ class GarminProcessor(Processor):
             )
 
         activity_id = int(match.groups()[1])
+
+        # Skip if the parent activity was deduped (garmin-health-data#67):
+        # the activity row was never inserted, so writing child rows
+        # referencing it would FK-fail and quarantine the FileSet.
+        if activity_id in self._skipped_activity_ids:
+            LOGGER.warning(
+                f"⚠️ Skipping FIT file for activity {activity_id} in "
+                f"{file_path.name}: parent activity was deduped (duplicate "
+                f"(user_id, start_ts))."
+            )
+            return
 
         # Verify activity exists (FIT file requires a parent activity record).
         existing_activity = (

--- a/dags/pipelines/garmin/process.py
+++ b/dags/pipelines/garmin/process.py
@@ -434,17 +434,22 @@ class GarminProcessor(Processor):
         self, activity_data: Dict[str, Any], session: Session
     ) -> Optional[int]:
         """
-        Extract activity fields and process to database using upsert with composite
-        primary key.
+        Extract activity fields and upsert the parent row in ``garmin.activity``.
+
+        The table is keyed by the single-column PK ``activity_id`` with a secondary
+        ``UNIQUE(user_id, start_ts)`` constraint. Upserts conflict on the PK; the UNIQUE
+        constraint is enforced separately, and this function detects a same-``(user_id,
+        start_ts)`` collision with a different ``activity_id`` before the upsert to
+        avoid an IntegrityError that would quarantine the whole FileSet (see garmin-
+        health-data#67).
 
         Uses pop() to remove processed fields from activity_data, enabling automatic
         supplemental metrics extraction without hardcoded exclusion lists.
 
-        Returns ``None`` when the activity is skipped (empty record, or a duplicate
-        ``(user_id, start_ts)`` collision with an existing activity in the database).
-        The caller treats ``None`` as "skip the rest of the per-activity pipeline" so
-        sport-specific aggregates and supplemental metrics are not attached to a non-
-        existent parent row.
+        Returns ``None`` when the activity is skipped (empty record, no derivable
+        ``end_ts``, or a duplicate-start_ts collision). The caller treats ``None`` as
+        "skip the rest of the per-activity pipeline" so sport-specific aggregates and
+        supplemental metrics are not attached to a non-existent parent row.
 
         :param activity_data: Activity data from JSON (will be modified by pop()).
         :param session: SQLAlchemy Session object.

--- a/dags/pipelines/garmin/process.py
+++ b/dags/pipelines/garmin/process.py
@@ -2464,6 +2464,15 @@ class GarminProcessor(Processor):
             ("MOOD", day_log.get("moods") or []),
             ("DISCHARGE", day_log.get("discharge") or []),
         ):
+            # Defensive: if Garmin ever returns a non-list (e.g. a single
+            # string), `for name in names` would iterate over characters and
+            # write one tag per char. Skip with a warning instead.
+            if not isinstance(names, list):
+                LOGGER.warning(
+                    f"⚠️ Skipping non-list {kind} payload in "
+                    f"{file_path.name}: {names!r}."
+                )
+                continue
             for name in names:
                 if not name:
                     continue

--- a/dags/pipelines/garmin/process.py
+++ b/dags/pipelines/garmin/process.py
@@ -451,7 +451,12 @@ class GarminProcessor(Processor):
         :return: Activity ID from the processed record, or ``None`` if skipped.
         """
         # Extract activity ID.
-        activity_id = activity_data.pop("activityId")
+        # Cast to int immediately: Garmin's JSON can return activityId as a
+        # string. Downstream code expects int (the BIGINT column, the
+        # _skipped_activity_ids set populated/queried by per-activity child
+        # processors that parse activity_id from filenames as int). Casting
+        # once here keeps types consistent throughout.
+        activity_id = int(activity_data.pop("activityId"))
 
         # Extract nested structures, all non-nullable, must be present.
         activity_type = activity_data.pop("activityType")

--- a/dags/pipelines/garmin/process.py
+++ b/dags/pipelines/garmin/process.py
@@ -462,6 +462,16 @@ class GarminProcessor(Processor):
                 end_dt = start_dt + timedelta(seconds=duration_seconds)
                 end_time_gmt_str = end_dt.isoformat()
 
+        # If both endTimeGMT and duration are absent we have no way to derive
+        # end_ts (the column is NOT NULL). Skip with a warning rather than
+        # raising on the fromisoformat(None) below.
+        if end_time_gmt_str is None:
+            LOGGER.warning(
+                f"⚠️ Skipping activity {activity_id}: no endTimeGMT and no "
+                f"duration to compute it from. Activity row cannot be created."
+            )
+            return None
+
         # Create timezone-aware datetimes and calculate offset.
         start_ts = datetime.fromisoformat(start_time_gmt_str).replace(
             tzinfo=timezone.utc

--- a/dags/pipelines/garmin/process.py
+++ b/dags/pipelines/garmin/process.py
@@ -472,12 +472,16 @@ class GarminProcessor(Processor):
 
         # If both endTimeGMT and duration are absent we have no way to derive
         # end_ts (the column is NOT NULL). Skip with a warning rather than
-        # raising on the fromisoformat(None) below.
+        # raising on the fromisoformat(None) below. Register the activity_id
+        # in _skipped_activity_ids so the FIT downloader's per-activity file
+        # processor short-circuits cleanly instead of FK-failing on the
+        # missing parent row and quarantining the FileSet.
         if end_time_gmt_str is None:
             LOGGER.warning(
                 f"⚠️ Skipping activity {activity_id}: no endTimeGMT and no "
                 f"duration to compute it from. Activity row cannot be created."
             )
+            self._skipped_activity_ids.add(activity_id)
             return None
 
         # Create timezone-aware datetimes and calculate offset.

--- a/dags/pipelines/garmin/sqla_models.py
+++ b/dags/pipelines/garmin/sqla_models.py
@@ -8,10 +8,12 @@ data defined in the tables.ddl file.
 from sqlalchemy import (
     BigInteger,
     Boolean,
+    CheckConstraint,
     Column,
     Date,
     DateTime,
     Float,
+    ForeignKeyConstraint,
     Integer,
     MetaData,
     String,
@@ -777,6 +779,87 @@ class Floors(InsertBase):
     timestamp = Column(DateTime(timezone=True), primary_key=True)
     ascended = Column(Integer)
     descended = Column(Integer)
+
+
+class MenstrualCycleDay(UpsertBase):
+    """
+    Daily menstrual cycle state from Garmin Connect's periodic-health service.
+
+    One row per day inside any observed or predicted cycle window. Re-extracting the
+    same day refreshes scalars via upsert. Tag-shaped sub-fields (symptoms, moods,
+    discharge) live in MenstrualCycleTag with delete-then-insert semantics on every
+    reprocess so user-removed tags propagate.
+    """
+
+    __tablename__ = "menstrual_cycle_day"
+
+    user_id = Column(BigInteger, fkey("garmin", "user", "user_id"), primary_key=True)
+    date = Column(Date, primary_key=True)
+    cycle_start_date = Column(Date)
+    day_in_cycle = Column(Integer)
+    period_length = Column(Integer)
+    current_phase = Column(String)
+    length_of_current_phase = Column(Integer)
+    days_until_next_phase = Column(Integer)
+    predicted_cycle_length = Column(Integer)
+    cycle_type = Column(String)
+    predicted_cycle = Column(Boolean)
+    flow = Column(String)
+    sex_drive = Column(String)
+    sexual_activity = Column(String)
+    notes = Column(Text)
+    report_ts = Column(DateTime(timezone=True))
+    has_baby_movement = Column(Boolean)
+    ovulation_day = Column(Boolean)
+
+
+class MenstrualCycleTag(InsertBase):
+    """
+    Polymorphic tag table for symptoms, moods, and discharge logged on a given day.
+
+    Cascade-deletes when the parent menstrual_cycle_day row is removed. Processor uses
+    delete-then-insert per (user_id, date) on every reprocess so user-removed tags
+    propagate.
+    """
+
+    __tablename__ = "menstrual_cycle_tag"
+
+    user_id = Column(BigInteger, primary_key=True)
+    date = Column(Date, primary_key=True)
+    kind = Column(String, primary_key=True)
+    name = Column(String, primary_key=True)
+
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["user_id", "date"],
+            ["garmin.menstrual_cycle_day.user_id", "garmin.menstrual_cycle_day.date"],
+            ondelete="CASCADE",
+        ),
+        CheckConstraint(
+            "kind IN ('SYMPTOM', 'MOOD', 'DISCHARGE')",
+            name="menstrual_cycle_tag_kind_valid",
+        ),
+        {"schema": "garmin"},
+    )
+
+
+class MenstrualCycleSummary(UpsertBase):
+    """
+    Per-cycle summaries from the menstrual cycle calendar endpoint.
+
+    Includes user-logged cycles (predicted_cycle=False) and Garmin's projections
+    (predicted_cycle=True). Predicted rows are wiped and re-inserted on every extract
+    because Garmin's projection dates shift as new data is logged; observed rows upsert
+    by (user_id, start_date). Cycle length is intentionally not stored: derive in SQL
+    via LEAD over start_date.
+    """
+
+    __tablename__ = "menstrual_cycle_summary"
+
+    user_id = Column(BigInteger, fkey("garmin", "user", "user_id"), primary_key=True)
+    start_date = Column(Date, primary_key=True)
+    period_length = Column(Integer)
+    predicted_cycle = Column(Boolean, nullable=False)
 
 
 class PersonalRecord(InsertBase):

--- a/dags/pipelines/garmin/tables.ddl
+++ b/dags/pipelines/garmin/tables.ddl
@@ -2042,6 +2042,206 @@ COMMENT ON COLUMN garmin.floors.create_ts IS
 'Timestamp when the record was created in the database.';
 
 ----------------------------------------------------------------------------------------
+
+-- Daily menstrual cycle state from Garmin Connect's periodic-health service. One row
+-- per day inside any observed or predicted cycle window. Combines the dayview
+-- endpoint's daySummary (computed cycle state, always present when the day falls in a
+-- cycle window) and dayLog (user-supplied data, NULL for days the user has not logged
+-- but that still fall inside a known or predicted cycle). Days outside every cycle
+-- window return a bare empty payload from the API and are skipped at extract time.
+-- Re-extracting the same day refreshes the row in place via upsert; tag-shaped
+-- sub-fields (symptoms, moods, discharge) live in menstrual_cycle_tag with
+-- delete-then-insert per (user_id, date) semantics so user removals propagate.
+CREATE TABLE IF NOT EXISTS garmin.menstrual_cycle_day (
+    user_id BIGINT NOT NULL REFERENCES garmin.user (user_id)
+    , date DATE NOT NULL
+    , cycle_start_date DATE
+    , day_in_cycle INTEGER
+    , period_length INTEGER
+    , current_phase TEXT
+    , length_of_current_phase INTEGER
+    , days_until_next_phase INTEGER
+    , predicted_cycle_length INTEGER
+    , cycle_type TEXT
+    , predicted_cycle BOOLEAN
+    , flow TEXT
+    , sex_drive TEXT
+    , sexual_activity TEXT
+    , notes TEXT
+    , report_ts TIMESTAMPTZ
+    , has_baby_movement BOOLEAN
+    , ovulation_day BOOLEAN
+
+    -- Audit fields.
+    , create_ts TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    , update_ts TIMESTAMPTZ NOT NULL DEFAULT NOW()
+
+    -- Primary key.
+    , PRIMARY KEY (user_id, date)
+);
+
+CREATE INDEX IF NOT EXISTS menstrual_cycle_day_user_id_date_idx
+ON garmin.menstrual_cycle_day (user_id, date DESC);
+
+-- Table comment.
+COMMENT ON TABLE garmin.menstrual_cycle_day IS
+'Per-day menstrual cycle state from Garmin Connect''s periodic-health dayview '
+'endpoint. One row per day inside any observed or predicted cycle window. Combines '
+'daySummary (computed cycle state) and dayLog (user-supplied data, NULL on '
+'unlogged predicted days). Re-extracting the same day upserts the row; tag-shaped '
+'sub-fields (symptoms, moods, discharge) live in menstrual_cycle_tag.';
+
+-- Column comments.
+COMMENT ON COLUMN garmin.menstrual_cycle_day.user_id IS
+'References garmin.user(user_id). Identifies which user this log belongs to.';
+COMMENT ON COLUMN garmin.menstrual_cycle_day.date IS
+'Calendar date of the log (dayLog.calendarDate, or the queried date when only '
+'daySummary is present).';
+COMMENT ON COLUMN garmin.menstrual_cycle_day.cycle_start_date IS
+'daySummary.startDate. Most recent period start anchoring this day''s day-in-cycle.';
+COMMENT ON COLUMN garmin.menstrual_cycle_day.day_in_cycle IS
+'1-based day index within the current cycle (daySummary.dayInCycle).';
+COMMENT ON COLUMN garmin.menstrual_cycle_day.period_length IS
+'Length of the current period in days (daySummary.periodLength).';
+COMMENT ON COLUMN garmin.menstrual_cycle_day.current_phase IS
+'Denormalized phase label: MENSTRUAL / FOLLICULAR / OVULATORY / LUTEAL. Sourced '
+'from daySummary.currentPhase (1-4 int) via MenstrualCyclePhase.';
+COMMENT ON COLUMN garmin.menstrual_cycle_day.length_of_current_phase IS
+'daySummary.lengthOfCurrentPhase.';
+COMMENT ON COLUMN garmin.menstrual_cycle_day.days_until_next_phase IS
+'daySummary.daysUntilNextPhase.';
+COMMENT ON COLUMN garmin.menstrual_cycle_day.predicted_cycle_length IS
+'daySummary.predictedCycleLength.';
+COMMENT ON COLUMN garmin.menstrual_cycle_day.cycle_type IS
+'daySummary.cycleType (e.g., ''REGULAR'', ''IRREGULAR'').';
+COMMENT ON COLUMN garmin.menstrual_cycle_day.predicted_cycle IS
+'daySummary.predictedCycle. TRUE means the cycle is a projection, FALSE means a '
+'user-logged period.';
+COMMENT ON COLUMN garmin.menstrual_cycle_day.flow IS
+'dayLog.flow: NONE / LIGHT / MEDIUM / HEAVY. Nullable when not logged.';
+COMMENT ON COLUMN garmin.menstrual_cycle_day.sex_drive IS
+'dayLog.sexDrive: NONE / LOW / AVERAGE / HIGH. Nullable.';
+COMMENT ON COLUMN garmin.menstrual_cycle_day.sexual_activity IS
+'dayLog.sexualActivity: NONE / UNPROTECTED / PROTECTED. Nullable.';
+COMMENT ON COLUMN garmin.menstrual_cycle_day.notes IS
+'dayLog.notes. Freeform user text. Nullable.';
+COMMENT ON COLUMN garmin.menstrual_cycle_day.report_ts IS
+'dayLog.reportTimestamp. Last time the user edited this day''s log.';
+COMMENT ON COLUMN garmin.menstrual_cycle_day.has_baby_movement IS
+'dayLog.hasBabyMovement.';
+COMMENT ON COLUMN garmin.menstrual_cycle_day.ovulation_day IS
+'dayLog.ovulationDay. User-marked ovulation flag.';
+COMMENT ON COLUMN garmin.menstrual_cycle_day.create_ts IS
+'Timestamp when the record was created in the database.';
+COMMENT ON COLUMN garmin.menstrual_cycle_day.update_ts IS
+'Timestamp when the record was last modified in the database.';
+
+----------------------------------------------------------------------------------------
+
+-- Polymorphic tag table for the three list-shaped fields on the dayview dayLog:
+-- symptoms, moods, and discharge. Each row is one tag the user logged on one day.
+-- Names are raw Garmin enum identifiers (e.g., 'BACKACHE', 'HAPPY', 'EGG_WHITE').
+-- Processor uses delete-then-insert per (user_id, date) so tags removed by the user
+-- propagate on the next extract.
+CREATE TABLE IF NOT EXISTS garmin.menstrual_cycle_tag (
+    user_id BIGINT NOT NULL
+    , date DATE NOT NULL
+    , kind TEXT NOT NULL
+    , name TEXT NOT NULL
+
+    -- Audit fields.
+    , create_ts TIMESTAMPTZ NOT NULL DEFAULT NOW()
+
+    -- Primary key.
+    , PRIMARY KEY (user_id, date, kind, name)
+
+    -- Composite FK to the parent day row with cascade delete so removing a day
+    -- automatically clears its tag children.
+    , FOREIGN KEY (user_id, date) REFERENCES garmin.menstrual_cycle_day (
+        user_id, date
+    ) ON DELETE CASCADE
+
+    -- Restrict kind to the three list-shaped fields the processor knows about.
+    , CONSTRAINT menstrual_cycle_tag_kind_valid CHECK (
+        kind IN ('SYMPTOM', 'MOOD', 'DISCHARGE')
+    )
+);
+
+CREATE INDEX IF NOT EXISTS menstrual_cycle_tag_kind_name_idx
+ON garmin.menstrual_cycle_tag (kind, name);
+
+-- Table comment.
+COMMENT ON TABLE garmin.menstrual_cycle_tag IS
+'Polymorphic tag table for the three list-shaped fields on the dayview dayLog: '
+'symptoms, moods, and discharge. Each row is one tag the user logged on one day. '
+'Processor uses delete-then-insert per (user_id, date) so user-removed tags '
+'propagate.';
+
+-- Column comments.
+COMMENT ON COLUMN garmin.menstrual_cycle_tag.user_id IS
+'References garmin.menstrual_cycle_day(user_id).';
+COMMENT ON COLUMN garmin.menstrual_cycle_tag.date IS
+'References garmin.menstrual_cycle_day(date).';
+COMMENT ON COLUMN garmin.menstrual_cycle_tag.kind IS
+'One of: SYMPTOM, MOOD, DISCHARGE.';
+COMMENT ON COLUMN garmin.menstrual_cycle_tag.name IS
+'Raw Garmin enum identifier for the tag.';
+COMMENT ON COLUMN garmin.menstrual_cycle_tag.create_ts IS
+'Timestamp when the record was created in the database.';
+
+----------------------------------------------------------------------------------------
+
+-- Per-cycle summaries from the menstrual cycle calendar endpoint. Includes both
+-- user-logged cycles (predicted_cycle=FALSE) and Garmin's projections of upcoming
+-- cycles (predicted_cycle=TRUE). Cycle length is intentionally not stored; derive in
+-- SQL via LEAD(start_date) OVER (PARTITION BY user_id ORDER BY start_date) -
+-- start_date. Predicted rows are wiped and re-inserted on every extract because
+-- Garmin's projection dates shift as new data is logged; observed rows use upsert by
+-- (user_id, start_date).
+CREATE TABLE IF NOT EXISTS garmin.menstrual_cycle_summary (
+    user_id BIGINT NOT NULL REFERENCES garmin.user (user_id)
+    , start_date DATE NOT NULL
+    , period_length INTEGER
+    , predicted_cycle BOOLEAN NOT NULL
+
+    -- Audit fields.
+    , create_ts TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    , update_ts TIMESTAMPTZ NOT NULL DEFAULT NOW()
+
+    -- Primary key.
+    , PRIMARY KEY (user_id, start_date)
+);
+
+CREATE INDEX IF NOT EXISTS menstrual_cycle_summary_user_id_start_date_idx
+ON garmin.menstrual_cycle_summary (user_id, start_date DESC);
+CREATE INDEX IF NOT EXISTS menstrual_cycle_summary_predicted_cycle_idx
+ON garmin.menstrual_cycle_summary (user_id, predicted_cycle);
+
+-- Table comment.
+COMMENT ON TABLE garmin.menstrual_cycle_summary IS
+'Per-cycle summaries from the menstrual cycle calendar endpoint. Includes '
+'user-logged cycles (predicted_cycle=FALSE) and Garmin''s projections '
+'(predicted_cycle=TRUE). Predicted rows are wiped and re-inserted on every extract '
+'because projection dates shift as new data is logged; observed rows upsert by '
+'(user_id, start_date). Cycle length is intentionally not stored: derive in SQL via '
+'LEAD over start_date.';
+
+-- Column comments.
+COMMENT ON COLUMN garmin.menstrual_cycle_summary.user_id IS
+'References garmin.user(user_id).';
+COMMENT ON COLUMN garmin.menstrual_cycle_summary.start_date IS
+'cycleSummaries[].startDate. Day the period began (or is predicted to begin).';
+COMMENT ON COLUMN garmin.menstrual_cycle_summary.period_length IS
+'cycleSummaries[].periodLength. Length of the period in days.';
+COMMENT ON COLUMN garmin.menstrual_cycle_summary.predicted_cycle IS
+'cycleSummaries[].predictedCycle. TRUE for Garmin projections, FALSE for '
+'user-logged cycles.';
+COMMENT ON COLUMN garmin.menstrual_cycle_summary.create_ts IS
+'Timestamp when the record was created in the database.';
+COMMENT ON COLUMN garmin.menstrual_cycle_summary.update_ts IS
+'Timestamp when the record was last modified in the database.';
+
+----------------------------------------------------------------------------------------
 -- Personal Record table
 ----------------------------------------------------------------------------------------
 

--- a/tests/dags/lib/test_sql_utils.py
+++ b/tests/dags/lib/test_sql_utils.py
@@ -279,9 +279,11 @@ class TestUpsertModelInstances:
 
     def test_upsert_values_default_update_columns_exclude_pk(self, db_session):
         """
-        Default `update_columns` excludes primary-key columns even when the PK is
-        not in `conflict_columns`. Prevents `SET pk = NULL` corruption when an
-        auto-increment PK is upserted with a separate uniqueness key.
+        Default `update_columns` excludes primary-key columns even when the PK is not in
+        `conflict_columns`.
+
+        Prevents `SET pk = NULL` corruption when an auto-increment PK is upserted with a
+        separate uniqueness key.
         """
         from sqlalchemy import Column, Integer, String, UniqueConstraint
         from sqlalchemy.orm import DeclarativeBase

--- a/tests/dags/pipelines/garmin/garmin_client/test_api.py
+++ b/tests/dags/pipelines/garmin/garmin_client/test_api.py
@@ -380,6 +380,94 @@ class TestGetBodyComposition:
 
 
 # ----------------------------------------------------------------------------------------
+# MENSTRUAL CYCLE
+# ----------------------------------------------------------------------------------------
+
+
+class TestGetMenstrualDataForDate:
+    """
+    Tests for ``get_menstrual_data_for_date`` (dayview endpoint).
+    """
+
+    def test_returns_payload_when_day_summary_or_log_present(
+        self, mock_client: MagicMock
+    ) -> None:
+        """
+        A dict response with a populated ``daySummary`` or ``dayLog`` must be returned
+        verbatim so the processor can extract fields.
+        """
+        mock_client._connectapi.return_value = {
+            "daySummary": {"currentPhase": 2},
+            "dayLog": None,
+        }
+        result = api.get_menstrual_data_for_date(mock_client, "2026-05-25")
+        assert result == {"daySummary": {"currentPhase": 2}, "dayLog": None}
+
+    def test_returns_none_for_bare_empty_dict(self, mock_client: MagicMock) -> None:
+        """
+        A dict response with neither ``daySummary`` nor ``dayLog`` (the "no cycle data
+        for this day" shape) must collapse to ``None``.
+        """
+        mock_client._connectapi.return_value = {}
+        assert api.get_menstrual_data_for_date(mock_client, "2026-05-25") is None
+
+    def test_returns_none_for_non_dict_payload(self, mock_client: MagicMock) -> None:
+        """
+        Defensive: a non-dict response (list, string, error page) must return ``None``
+        instead of raising ``AttributeError`` on ``result.get(...)``.
+        """
+        for bad_payload in (None, [], "error", 42):
+            mock_client._connectapi.return_value = bad_payload
+            assert api.get_menstrual_data_for_date(mock_client, "2026-05-25") is None
+
+
+class TestGetMenstrualCalendarData:
+    """
+    Tests for ``get_menstrual_calendar_data`` (calendar endpoint with pagination).
+    """
+
+    def test_returns_none_when_all_chunks_non_dict(
+        self, mock_client: MagicMock
+    ) -> None:
+        """
+        If every chunk's response is non-dict (e.g. an error page on every page of a
+        multi-chunk range), the function returns ``None`` instead of raising.
+        """
+        mock_client._connectapi.return_value = "error"
+        result = api.get_menstrual_calendar_data(
+            mock_client, "2026-01-01", "2026-06-01"
+        )
+        assert result is None
+
+    def test_skips_non_dict_chunks_and_merges_dict_chunks(
+        self, mock_client: MagicMock
+    ) -> None:
+        """
+        A mixed response sequence (one non-dict chunk, one dict chunk) must skip the bad
+        chunk and still return the good chunk's merged content.
+
+        The bad chunk must not abort pagination.
+        """
+        mock_client._connectapi.side_effect = [
+            "error_page",  # First chunk non-dict.
+            {  # Second chunk normal.
+                "cycleSummaries": [{"startDate": "2026-04-05", "periodLength": 5}],
+                "loggedSymptomDays": ["2026-04-05"],
+                "loggedOvulationDays": [],
+                "loggedNoteDays": [],
+            },
+        ]
+        result = api.get_menstrual_calendar_data(
+            mock_client, "2026-01-01", "2026-06-01"
+        )
+        assert result is not None
+        assert result["cycleSummaries"] == [
+            {"startDate": "2026-04-05", "periodLength": 5}
+        ]
+        assert result["loggedSymptomDays"] == ["2026-04-05"]
+
+
+# ----------------------------------------------------------------------------------------
 # RANGE ACTIVITIES
 # ----------------------------------------------------------------------------------------
 

--- a/tests/dags/pipelines/garmin/test_extract.py
+++ b/tests/dags/pipelines/garmin/test_extract.py
@@ -265,16 +265,19 @@ class TestGarminExtractor:
         )
         mock_sleep.assert_called()
 
-    @patch("dags.pipelines.garmin.extract.time.sleep")
     @patch("dags.pipelines.garmin.extract.LOGGER")
     def test_extract_data_by_type_range(
-        self, mock_logger, mock_sleep, extractor, mock_garmin_client
+        self, mock_logger, extractor, mock_garmin_client
     ) -> None:
         """
         Test _extract_data_by_type with RANGE parameter type.
 
+        Post-port (PR #65), RANGE types issue ONE API call covering the full window (not
+        one per day). For unsplittable RANGE types (anything not BODY_COMPOSITION or
+        ACTIVITIES_LIST), the response is written as a single file stamped with
+        end_date. The synthetic BODY_BATTERY type used here exercises that path.
+
         :param mock_logger: Mock logger.
-        :param mock_sleep: Mock sleep function.
         :param extractor: GarminExtractor fixture.
         :param mock_garmin_client: Mock Garmin client fixture.
         """
@@ -292,7 +295,7 @@ class TestGarminExtractor:
             emoji="battery",
         )
 
-        mock_garmin_client.get_body_battery.return_value = {"data": []}
+        mock_garmin_client.get_body_battery.return_value = {"data": [{"x": 1}]}
 
         # Act.
         result = extractor._extract_data_by_type(
@@ -300,16 +303,13 @@ class TestGarminExtractor:
         )
 
         # Assert.
-        assert len(result) == 3  # 3 days (inclusive end date).
-        assert mock_garmin_client.get_body_battery.call_count == 3
-        mock_garmin_client.get_body_battery.assert_has_calls(
-            [
-                call("2025-01-01", "2025-01-01"),
-                call("2025-01-02", "2025-01-02"),
-                call("2025-01-03", "2025-01-03"),
-            ]
+        # One API call for the full window (the perf win), and one file stamped with
+        # end_date for the unsplittable RANGE type.
+        assert len(result) == 1
+        mock_garmin_client.get_body_battery.assert_called_once_with(
+            "2025-01-01", "2025-01-03"
         )
-        mock_sleep.assert_called()
+        assert "2025-01-03" in result[0].name
 
     @patch("dags.pipelines.garmin.extract.LOGGER")
     def test_extract_data_by_type_no_date(

--- a/tests/dags/pipelines/garmin/test_extract_range.py
+++ b/tests/dags/pipelines/garmin/test_extract_range.py
@@ -220,3 +220,28 @@ class TestExtractRange:
 
         assert saved == []
         assert extractor.failures == []
+
+    def test_menstrual_cycle_summary_writes_single_file_stamped_end_date(
+        self, extractor: GarminExtractor
+    ) -> None:
+        """
+        MENSTRUAL_CYCLE_SUMMARY is an unsplittable RANGE type: the wipe-and-replace
+        policy needs to see the whole new set in one transaction, so the response is
+        written as a single file stamped with end_date.
+        """
+        extractor.start_date = date(2026, 1, 1)
+        extractor.end_date = date(2026, 3, 1)
+        extractor.garmin_client.get_menstrual_calendar_data.return_value = {
+            "cycleSummaries": [
+                {"startDate": "2026-01-05", "periodLength": 5, "predictedCycle": False},
+                {"startDate": "2026-02-05", "periodLength": 5, "predictedCycle": True},
+            ]
+        }
+
+        summary = GARMIN_DATA_REGISTRY.get_by_name("MENSTRUAL_CYCLE_SUMMARY")
+        files = extractor._extract_data_by_type(
+            summary, date(2026, 1, 1), date(2026, 3, 1)
+        )
+
+        assert len(files) == 1
+        assert "MENSTRUAL_CYCLE_SUMMARY_2026-03-01" in files[0].name

--- a/tests/dags/pipelines/garmin/test_extract_range.py
+++ b/tests/dags/pipelines/garmin/test_extract_range.py
@@ -1,0 +1,222 @@
+"""
+Tests for RANGE-typed extraction in dags.pipelines.garmin.extract.
+
+This module covers the per-window RANGE extraction pattern introduced by porting garmin-
+health-data#65: RANGE-typed data types now issue ONE API call per window (was N day-by-
+day calls), with per-day file splitting downstream so the processor's ``(user, day)``
+FileSet abstraction is preserved.
+
+Tests use MagicMock for the Garmin client; no network calls are made.
+"""
+
+import json
+
+from datetime import date
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from dags.pipelines.garmin.constants import GARMIN_DATA_REGISTRY
+from dags.pipelines.garmin.extract import ExtractionFailure, GarminExtractor
+
+
+@pytest.fixture
+def extractor(tmp_path: Path) -> GarminExtractor:
+    """
+    Build a GarminExtractor over a fixed 5-day window with mocked client and user_id.
+
+    :param tmp_path: Pytest temporary directory fixture.
+    :return: GarminExtractor instance ready for RANGE-extraction tests.
+    """
+    instance = GarminExtractor(
+        start_date=date(2026, 1, 1),
+        end_date=date(2026, 1, 5),
+        ingest_dir=tmp_path,
+    )
+    instance.user_id = "123"
+    instance.garmin_client = MagicMock()
+    return instance
+
+
+class TestExtractRange:
+    """
+    Tests for ``GarminExtractor._extract_data_by_type`` on RANGE-typed data types.
+    """
+
+    def test_range_typed_data_calls_api_once_for_full_window(
+        self, extractor: GarminExtractor
+    ) -> None:
+        """
+        RANGE-typed data types must hit the API exactly once for the full window.
+
+        Before the port, the extractor faked RANGE by passing the same date to both
+        ``startdate`` and ``enddate`` per day, making N API calls for an N-day window.
+        Post-port, ``_extract_range`` makes a single call covering the whole window.
+        """
+        body_comp = GARMIN_DATA_REGISTRY.get_by_name("BODY_COMPOSITION")
+        extractor.garmin_client.get_body_composition.return_value = {
+            "dateWeightList": [
+                {"calendarDate": "2026-01-01", "weight": 75000.0},
+                {"calendarDate": "2026-01-03", "weight": 74800.0},
+            ]
+        }
+
+        extractor._extract_data_by_type(body_comp, date(2026, 1, 1), date(2026, 1, 5))
+
+        extractor.garmin_client.get_body_composition.assert_called_once_with(
+            "2026-01-01", "2026-01-05"
+        )
+
+    def test_body_composition_response_is_split_per_day(
+        self, extractor: GarminExtractor
+    ) -> None:
+        """
+        ``BODY_COMPOSITION`` per-window responses are split into one file per calendar
+        date that had at least one entry.
+
+        Days with no entries produce no file. Each per-day file is a dict with a
+        ``dateWeightList`` key containing only the entries whose ``calendarDate``
+        matches the bucket date, preserving the per-day file shape the downstream
+        processor expects.
+        """
+        body_comp = GARMIN_DATA_REGISTRY.get_by_name("BODY_COMPOSITION")
+        extractor.garmin_client.get_body_composition.return_value = {
+            "dateWeightList": [
+                {"calendarDate": "2026-01-01", "weight": 75000.0},
+                {"calendarDate": "2026-01-01", "weight": 74800.0},
+                {"calendarDate": "2026-01-03", "weight": 74500.0},
+            ]
+        }
+
+        saved = extractor._extract_data_by_type(
+            body_comp, date(2026, 1, 1), date(2026, 1, 5)
+        )
+
+        # Exactly two files: one for 2026-01-01, one for 2026-01-03.
+        # Nothing for 01-02 / 01-04 / 01-05 (no entries).
+        assert len(saved) == 2
+        names = sorted(p.name for p in saved)
+        assert "BODY_COMPOSITION_2026-01-01" in names[0]
+        assert "BODY_COMPOSITION_2026-01-03" in names[1]
+
+        # The 2026-01-01 file should contain a dict with dateWeightList of
+        # exactly its 2 entries.
+        day1_file = next(p for p in saved if "2026-01-01" in p.name)
+        with open(day1_file, "r", encoding="utf-8") as f:
+            payload = json.load(f)
+        assert isinstance(payload, dict)
+        assert "dateWeightList" in payload
+        assert len(payload["dateWeightList"]) == 2
+        for entry in payload["dateWeightList"]:
+            assert entry["calendarDate"] == "2026-01-01"
+
+    def test_activities_list_response_is_split_per_day(
+        self, extractor: GarminExtractor
+    ) -> None:
+        """
+        ``ACTIVITIES_LIST`` per-window responses are split into one file per local date
+        by ``startTimeLocal``.
+
+        Each per-day file is a JSON list of the activity dicts whose ``startTimeLocal``
+        date matches the bucket date.
+        """
+        activities_list = GARMIN_DATA_REGISTRY.get_by_name("ACTIVITIES_LIST")
+        extractor.garmin_client.get_activities_by_date.return_value = [
+            {"activityId": 1, "startTimeLocal": "2026-01-01T08:00:00"},
+            {"activityId": 2, "startTimeLocal": "2026-01-01T18:00:00"},
+            {"activityId": 3, "startTimeLocal": "2026-01-03T07:00:00"},
+        ]
+
+        saved = extractor._extract_data_by_type(
+            activities_list, date(2026, 1, 1), date(2026, 1, 5)
+        )
+
+        # Single API call: the perf win.
+        extractor.garmin_client.get_activities_by_date.assert_called_once_with(
+            "2026-01-01", "2026-01-05"
+        )
+        # Two files (one per local-date with activities).
+        assert len(saved) == 2
+        names = sorted(p.name for p in saved)
+        assert "ACTIVITIES_LIST_2026-01-01" in names[0]
+        assert "ACTIVITIES_LIST_2026-01-03" in names[1]
+
+        # The 2026-01-01 file contains a list of exactly the 2 day-1 activities.
+        day1_file = next(p for p in saved if "2026-01-01" in p.name)
+        with open(day1_file, "r", encoding="utf-8") as f:
+            payload = json.load(f)
+        assert isinstance(payload, list)
+        assert [a["activityId"] for a in payload] == [1, 2]
+
+        # The 2026-01-03 file contains a list of exactly the 1 day-3 activity.
+        day3_file = next(p for p in saved if "2026-01-03" in p.name)
+        with open(day3_file, "r", encoding="utf-8") as f:
+            payload = json.load(f)
+        assert isinstance(payload, list)
+        assert [a["activityId"] for a in payload] == [3]
+
+    def test_per_activity_type_returns_empty_from_dispatch(
+        self, extractor: GarminExtractor
+    ) -> None:
+        """
+        ``PER_ACTIVITY``-classified data types short-circuit out of the date-driven
+        dispatcher because they're iterated per activity_id by
+        ``extract_fit_activities``, not per calendar date.
+
+        Regression guard: a routing error (e.g. accidentally sending them through
+        ``_extract_range``) would call the API with date params it doesn't accept.
+        """
+        activity = GARMIN_DATA_REGISTRY.get_by_name("ACTIVITY")
+        exercise_sets = GARMIN_DATA_REGISTRY.get_by_name("EXERCISE_SETS")
+
+        for data_type in (activity, exercise_sets):
+            result = extractor._extract_data_by_type(
+                data_type, date(2026, 1, 1), date(2026, 1, 5)
+            )
+            assert result == []
+        # No API methods on the client were invoked by the dispatcher.
+        extractor.garmin_client.download_activity.assert_not_called()
+        extractor.garmin_client.get_activity_exercise_sets.assert_not_called()
+
+    def test_range_failure_records_window_label(
+        self, extractor: GarminExtractor
+    ) -> None:
+        """
+        A failure during the per-range API call records the ``"{start}..{end}"`` window
+        label in :attr:`failures`, conveying the blast radius of the failure (whole
+        window, not one day).
+        """
+        body_comp = GARMIN_DATA_REGISTRY.get_by_name("BODY_COMPOSITION")
+        extractor.garmin_client.get_body_composition.side_effect = RuntimeError(
+            "API outage"
+        )
+
+        saved = extractor._extract_data_by_type(
+            body_comp, date(2026, 1, 1), date(2026, 1, 5)
+        )
+
+        assert saved == []
+        assert len(extractor.failures) == 1
+        failure: ExtractionFailure = extractor.failures[0]
+        assert failure.data_type == "BODY_COMPOSITION"
+        assert failure.date == "2026-01-01..2026-01-05"
+        assert failure.user_id == "123"
+        assert "API outage" in failure.error
+
+    def test_range_empty_response_writes_no_file(
+        self, extractor: GarminExtractor
+    ) -> None:
+        """
+        A falsy API response yields no saved file and no recorded failure: matches the
+        existing DAILY behavior for empty days.
+        """
+        body_comp = GARMIN_DATA_REGISTRY.get_by_name("BODY_COMPOSITION")
+        extractor.garmin_client.get_body_composition.return_value = None
+
+        saved = extractor._extract_data_by_type(
+            body_comp, date(2026, 1, 1), date(2026, 1, 5)
+        )
+
+        assert saved == []
+        assert extractor.failures == []

--- a/tests/dags/pipelines/garmin/test_extract_range.py
+++ b/tests/dags/pipelines/garmin/test_extract_range.py
@@ -179,6 +179,57 @@ class TestExtractRange:
         extractor.garmin_client.download_activity.assert_not_called()
         extractor.garmin_client.get_activity_exercise_sets.assert_not_called()
 
+    def test_splitter_skips_non_dict_entries_in_body_composition(
+        self, extractor: GarminExtractor
+    ) -> None:
+        """
+        The splitter must not call ``.get(...)`` on a non-dict ``dateWeightList`` entry.
+
+        A malformed payload that interleaves dicts with strings or other primitives must
+        skip the bad entries and process the good ones, mirroring the defensive
+        tolerance of ``_load_activities_list_from_disk``.
+        """
+        body_comp = GARMIN_DATA_REGISTRY.get_by_name("BODY_COMPOSITION")
+        extractor.garmin_client.get_body_composition.return_value = {
+            "dateWeightList": [
+                "not-a-dict",  # Bad entry, should be skipped.
+                {"calendarDate": "2026-01-02", "weight": 70000.0},  # Good entry.
+                12345,  # Bad entry, should be skipped.
+            ]
+        }
+
+        saved = extractor._extract_data_by_type(
+            body_comp, date(2026, 1, 1), date(2026, 1, 5)
+        )
+
+        # Only the one good entry produces a file (2026-01-02).
+        assert len(saved) == 1
+        assert "BODY_COMPOSITION_2026-01-02" in saved[0].name
+
+    def test_splitter_skips_non_dict_entries_in_activities_list(
+        self, extractor: GarminExtractor
+    ) -> None:
+        """
+        The splitter must not call ``.get(...)`` on a non-dict ``ACTIVITIES_LIST``
+        entry.
+
+        If the API ever returns a wrapper or interleaves non-dicts, the bad entries are
+        skipped and the good ones still land in their per-day files.
+        """
+        activities_list = GARMIN_DATA_REGISTRY.get_by_name("ACTIVITIES_LIST")
+        extractor.garmin_client.get_activities_by_date.return_value = [
+            "not-a-dict",
+            {"activityId": 1, "startTimeLocal": "2026-01-02T08:00:00"},
+            None,
+        ]
+
+        saved = extractor._extract_data_by_type(
+            activities_list, date(2026, 1, 1), date(2026, 1, 5)
+        )
+
+        assert len(saved) == 1
+        assert "ACTIVITIES_LIST_2026-01-02" in saved[0].name
+
     def test_range_failure_records_window_label(
         self, extractor: GarminExtractor
     ) -> None:

--- a/tests/dags/pipelines/garmin/test_extract_range.py
+++ b/tests/dags/pipelines/garmin/test_extract_range.py
@@ -115,11 +115,13 @@ class TestExtractRange:
         self, extractor: GarminExtractor
     ) -> None:
         """
-        ``ACTIVITIES_LIST`` per-window responses are split into one file per local date
-        by ``startTimeLocal``.
+        ``ACTIVITIES_LIST`` per-window responses are split into one file per day in the
+        window by ``startTimeLocal``.
 
-        Each per-day file is a JSON list of the activity dicts whose ``startTimeLocal``
-        date matches the bucket date.
+        Every day in the window gets a file. Days with at least one activity get a non-
+        empty JSON list; days with zero activities get an empty list ([]). The per-day
+        completeness is required by ``_load_activities_list_from_disk`` to trust the on-
+        disk cache and skip a second API call when ``extract_fit_activities`` runs.
         """
         activities_list = GARMIN_DATA_REGISTRY.get_by_name("ACTIVITIES_LIST")
         extractor.garmin_client.get_activities_by_date.return_value = [
@@ -136,11 +138,17 @@ class TestExtractRange:
         extractor.garmin_client.get_activities_by_date.assert_called_once_with(
             "2026-01-01", "2026-01-05"
         )
-        # Two files (one per local-date with activities).
-        assert len(saved) == 2
+        # Five files: one per day in the 5-day window.
+        assert len(saved) == 5
         names = sorted(p.name for p in saved)
-        assert "ACTIVITIES_LIST_2026-01-01" in names[0]
-        assert "ACTIVITIES_LIST_2026-01-03" in names[1]
+        for day_iso in (
+            "2026-01-01",
+            "2026-01-02",
+            "2026-01-03",
+            "2026-01-04",
+            "2026-01-05",
+        ):
+            assert any(f"ACTIVITIES_LIST_{day_iso}" in n for n in names)
 
         # The 2026-01-01 file contains a list of exactly the 2 day-1 activities.
         day1_file = next(p for p in saved if "2026-01-01" in p.name)
@@ -155,6 +163,14 @@ class TestExtractRange:
             payload = json.load(f)
         assert isinstance(payload, list)
         assert [a["activityId"] for a in payload] == [3]
+
+        # The 2026-01-02 file (no activities) is a present-but-empty list, not
+        # absent. Required so _load_activities_list_from_disk sees full window
+        # coverage and the FIT downloader can use the on-disk cache.
+        day2_file = next(p for p in saved if "2026-01-02" in p.name)
+        with open(day2_file, "r", encoding="utf-8") as f:
+            payload = json.load(f)
+        assert payload == []
 
     def test_per_activity_type_returns_empty_from_dispatch(
         self, extractor: GarminExtractor
@@ -227,8 +243,14 @@ class TestExtractRange:
             activities_list, date(2026, 1, 1), date(2026, 1, 5)
         )
 
-        assert len(saved) == 1
-        assert "ACTIVITIES_LIST_2026-01-02" in saved[0].name
+        # 5 files (one per day in window) — bad entries skipped, good entry in
+        # the 01-02 bucket, the other 4 days are present-but-empty.
+        assert len(saved) == 5
+        day2_file = next(p for p in saved if "2026-01-02" in p.name)
+        with open(day2_file, "r", encoding="utf-8") as f:
+            payload = json.load(f)
+        assert isinstance(payload, list)
+        assert [a["activityId"] for a in payload] == [1]
 
     def test_range_failure_records_window_label(
         self, extractor: GarminExtractor

--- a/tests/dags/pipelines/garmin/test_garmin_client_delegator_coverage.py
+++ b/tests/dags/pipelines/garmin/test_garmin_client_delegator_coverage.py
@@ -1,0 +1,38 @@
+"""
+Parametric coverage test for ``GarminClient`` delegators.
+
+The extractor calls ``getattr(self.garmin_client, data_type.api_method)``. A delegator
+method missing from ``GarminClient`` would raise ``AttributeError`` only at extract
+time: the unit tests for the plain ``api.<method>`` functions can't catch it because
+they call the module-level function directly. This parametric test walks
+``GARMIN_DATA_REGISTRY`` and asserts every registered ``api_method`` is a callable
+attribute on ``GarminClient``.
+
+Mirrors the regression guard from garmin-health-data#63 / #65.
+"""
+
+import pytest
+
+from dags.pipelines.garmin.constants import GARMIN_DATA_REGISTRY
+from dags.pipelines.garmin.garmin_client import GarminClient
+
+
+@pytest.mark.parametrize(
+    "data_type",
+    GARMIN_DATA_REGISTRY.all_data_types,
+    ids=lambda dt: dt.name,
+)
+def test_every_registered_api_method_exists_on_client(data_type) -> None:
+    """
+    Every registered ``api_method`` must be a callable attribute on ``GarminClient``.
+
+    :param data_type: GarminDataType iterated over by pytest parametrize.
+    """
+    method = getattr(GarminClient, data_type.api_method, None)
+    assert method is not None, (
+        f"GarminClient is missing delegator for {data_type.name}: "
+        f"expected attribute '{data_type.api_method}' was not found."
+    )
+    assert callable(
+        method
+    ), f"GarminClient.{data_type.api_method} exists but is not callable."

--- a/tests/dags/pipelines/garmin/test_process.py
+++ b/tests/dags/pipelines/garmin/test_process.py
@@ -12,7 +12,7 @@ This test suite covers:
 import copy
 import json
 import tempfile
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import Dict, List
 from unittest.mock import MagicMock, patch
@@ -35,6 +35,9 @@ from dags.pipelines.garmin.sqla_models import (
     BreathingDisruption,
     HeartRate,
     HRV,
+    MenstrualCycleDay,
+    MenstrualCycleSummary,
+    MenstrualCycleTag,
     PersonalRecord,
     RacePredictions,
     Respiration,
@@ -6231,6 +6234,374 @@ class TestGarminProcessor:
         # Assert - delete is called to clean stale rows, but no inserts.
         mock_session.execute.assert_called()
         mock_session.add_all.assert_not_called()
+
+
+def _menstrual_day_payload(
+    symptoms=None,
+    moods=None,
+    discharge=None,
+    phase=1,
+    flow="HEAVY",
+    notes="test",
+    ovulation_day=True,
+    report_ts="2026-05-25T18:34:49.9",
+    calendar_date="2026-05-25",
+    cycle_start_date="2026-05-23",
+):
+    """
+    Build a representative MENSTRUAL_CYCLE_DAY JSON payload (probe-shaped).
+
+    :param symptoms: List of symptom names; defaults to ``['BACKACHE', 'CRAMPS']``.
+    :param moods: List of mood names; defaults to ``['HAPPY']``.
+    :param discharge: List of discharge names; defaults to ``['CREAMY']``.
+    :param phase: Integer phase code (1=MENSTRUAL through 4=LUTEAL).
+    :param flow: Flow level string.
+    :param notes: User freeform notes.
+    :param ovulation_day: User-marked ovulation flag.
+    :param report_ts: ISO 8601 reportTimestamp string from Garmin.
+    :param calendar_date: dayLog.calendarDate string.
+    :param cycle_start_date: daySummary.startDate string.
+    :return: Dict matching the Garmin dayview response shape.
+    """
+    return {
+        "daySummary": {
+            "startDate": cycle_start_date,
+            "dayInCycle": 3,
+            "periodLength": 3,
+            "currentPhase": phase,
+            "lengthOfCurrentPhase": 3,
+            "daysUntilNextPhase": 1,
+            "predictedCycleLength": 28,
+            "cycleType": "REGULAR",
+            "predictedCycle": False,
+        },
+        "dayLog": {
+            "userProfilePk": 999,
+            "calendarDate": calendar_date,
+            "symptoms": symptoms if symptoms is not None else ["BACKACHE", "CRAMPS"],
+            "moods": moods if moods is not None else ["HAPPY"],
+            "discharge": discharge if discharge is not None else ["CREAMY"],
+            "flow": flow,
+            "sexDrive": "AVERAGE",
+            "sexualActivity": "PROTECTED",
+            "notes": notes,
+            "reportTimestamp": report_ts,
+            "hasBabyMovement": False,
+            "ovulationDay": ovulation_day,
+        },
+    }
+
+
+class TestMenstrualCycleProcessing:
+    """
+    Tests for MENSTRUAL_CYCLE_DAY and MENSTRUAL_CYCLE_SUMMARY processors.
+
+    Uses MagicMock for the session and patches ``upsert_model_instances`` to verify
+    call shape. The delete-then-insert tag pattern is exercised via ``session.execute``
+    + ``session.add_all`` assertions.
+    """
+
+    @pytest.fixture
+    def temp_dir(self):
+        """
+        Create temporary directory for testing.
+
+        :return: Temporary directory path.
+        """
+        with tempfile.TemporaryDirectory() as td:
+            yield Path(td)
+
+    @pytest.fixture
+    def mock_session(self) -> MagicMock:
+        """
+        Create mock SQLAlchemy session for testing.
+
+        :return: Mock session.
+        """
+        session = MagicMock()
+        return session
+
+    @pytest.fixture
+    def processor(self) -> GarminProcessor:
+        """
+        Create a GarminProcessor with ``user_id`` pre-set so processors can run.
+
+        :return: GarminProcessor instance with ``user_id=999``.
+        """
+        proc = _make_test_processor()
+        proc.user_id = 999
+        return proc
+
+    @patch("dags.pipelines.garmin.process.upsert_model_instances")
+    def test_menstrual_cycle_day_upserts_scalar_row(
+        self, mock_upsert, processor, mock_session, temp_dir
+    ):
+        """
+        A populated dayview file must upsert the scalar row and add all tag children.
+
+        :param mock_upsert: Patched upsert_model_instances.
+        :param processor: GarminProcessor fixture.
+        :param mock_session: Mock session fixture.
+        :param temp_dir: Temporary directory fixture.
+        """
+        data = _menstrual_day_payload(
+            symptoms=["BACKACHE"], moods=[], discharge=[], phase=2
+        )
+        file_path = temp_dir / "999_MENSTRUAL_CYCLE_DAY_2026-05-25T12-00-00Z.json"
+        with open(file_path, "w", encoding="utf-8") as f:
+            json.dump(data, f)
+
+        processor._process_menstrual_cycle_day(file_path, mock_session)
+
+        # Assert one upsert call carrying a single MenstrualCycleDay with the
+        # denormalized phase label.
+        mock_upsert.assert_called_once()
+        kwargs = mock_upsert.call_args.kwargs
+        assert kwargs["session"] == mock_session
+        assert kwargs["conflict_columns"] == ["user_id", "date"]
+        assert kwargs["on_conflict_update"] is True
+        records = kwargs["model_instances"]
+        assert len(records) == 1
+        day_record = records[0]
+        assert isinstance(day_record, MenstrualCycleDay)
+        assert day_record.user_id == 999
+        assert day_record.date == date(2026, 5, 25)
+        assert day_record.current_phase == "FOLLICULAR"
+        assert day_record.day_in_cycle == 3
+        assert day_record.predicted_cycle is False
+        assert day_record.flow == "HEAVY"
+        assert day_record.notes == "test"
+        assert day_record.ovulation_day is True
+        # report_ts must be parsed as a timezone-aware UTC datetime so the
+        # TIMESTAMPTZ column round-trips correctly. "2026-05-25T18:34:49.9"
+        # has no offset suffix; the parser stamps UTC.
+        assert day_record.report_ts == datetime(
+            2026, 5, 25, 18, 34, 49, 900000, tzinfo=timezone.utc
+        )
+
+        # Assert the tag delete was issued before the insert.
+        assert mock_session.execute.call_count >= 1
+
+        # Assert session.add_all received the single SYMPTOM tag.
+        mock_session.add_all.assert_called_once()
+        added = mock_session.add_all.call_args.args[0]
+        assert len(added) == 1
+        tag = added[0]
+        assert isinstance(tag, MenstrualCycleTag)
+        assert tag.user_id == 999
+        assert tag.date == date(2026, 5, 25)
+        assert tag.kind == "SYMPTOM"
+        assert tag.name == "BACKACHE"
+
+    @patch("dags.pipelines.garmin.process.upsert_model_instances")
+    def test_menstrual_cycle_day_unknown_phase_falls_back_to_unknown_label(
+        self, mock_upsert, processor, mock_session, temp_dir
+    ):
+        """
+        Unknown phase integers persist as ``UNKNOWN_<n>`` with a logged warning.
+
+        :param mock_upsert: Patched upsert_model_instances.
+        :param processor: GarminProcessor fixture.
+        :param mock_session: Mock session fixture.
+        :param temp_dir: Temporary directory fixture.
+        """
+        data = _menstrual_day_payload(phase=99)
+        file_path = temp_dir / "999_MENSTRUAL_CYCLE_DAY_2026-05-25T12-00-00Z.json"
+        with open(file_path, "w", encoding="utf-8") as f:
+            json.dump(data, f)
+
+        with patch("dags.pipelines.garmin.process.LOGGER.warning") as mock_warn:
+            processor._process_menstrual_cycle_day(file_path, mock_session)
+
+        records = mock_upsert.call_args.kwargs["model_instances"]
+        assert records[0].current_phase == "UNKNOWN_99"
+        assert mock_warn.called
+        # The warning must reference the unknown phase code.
+        warning_args = [c.args[0] for c in mock_warn.call_args_list]
+        assert any("99" in msg for msg in warning_args)
+
+    @patch("dags.pipelines.garmin.process.upsert_model_instances")
+    def test_menstrual_cycle_day_tag_delete_then_insert_with_three_tags(
+        self, mock_upsert, processor, mock_session, temp_dir
+    ):
+        """
+        First-run shape: a file with three tags must delete then add_all([A, B, C]).
+
+        :param mock_upsert: Patched upsert_model_instances.
+        :param processor: GarminProcessor fixture.
+        :param mock_session: Mock session fixture.
+        :param temp_dir: Temporary directory fixture.
+        """
+        data = _menstrual_day_payload(
+            symptoms=["BACKACHE", "CRAMPS", "HEADACHE"],
+            moods=[],
+            discharge=[],
+        )
+        file_path = temp_dir / "999_MENSTRUAL_CYCLE_DAY_2026-05-25T12-00-00Z.json"
+        with open(file_path, "w", encoding="utf-8") as f:
+            json.dump(data, f)
+
+        processor._process_menstrual_cycle_day(file_path, mock_session)
+
+        # Delete-then-insert: at least one session.execute call (the DELETE), and
+        # session.add_all called with three records.
+        assert mock_session.execute.call_count >= 1
+        mock_session.add_all.assert_called_once()
+        added = mock_session.add_all.call_args.args[0]
+        assert len(added) == 3
+        names = sorted(t.name for t in added)
+        assert names == ["BACKACHE", "CRAMPS", "HEADACHE"]
+        assert all(t.kind == "SYMPTOM" for t in added)
+
+    @patch("dags.pipelines.garmin.process.upsert_model_instances")
+    def test_menstrual_cycle_day_tag_delete_then_insert_with_one_tag(
+        self, mock_upsert, processor, mock_session, temp_dir
+    ):
+        """
+        Reprocess-after-removal shape: a file with one tag still issues the DELETE and
+        adds only one record. Complements
+        ``test_menstrual_cycle_day_tag_delete_then_insert_with_three_tags`` to confirm
+        the count of added tags tracks the payload, not accumulated state.
+
+        :param mock_upsert: Patched upsert_model_instances.
+        :param processor: GarminProcessor fixture.
+        :param mock_session: Mock session fixture.
+        :param temp_dir: Temporary directory fixture.
+        """
+        data = _menstrual_day_payload(symptoms=["BACKACHE"], moods=[], discharge=[])
+        file_path = temp_dir / "999_MENSTRUAL_CYCLE_DAY_2026-05-25T12-00-00Z.json"
+        with open(file_path, "w", encoding="utf-8") as f:
+            json.dump(data, f)
+
+        processor._process_menstrual_cycle_day(file_path, mock_session)
+
+        assert mock_session.execute.call_count >= 1
+        mock_session.add_all.assert_called_once()
+        added = mock_session.add_all.call_args.args[0]
+        assert len(added) == 1
+        assert added[0].name == "BACKACHE"
+
+    @patch("dags.pipelines.garmin.process.upsert_model_instances")
+    def test_menstrual_cycle_summary_wipes_predicted_then_upserts(
+        self, mock_upsert, processor, mock_session, temp_dir
+    ):
+        """
+        A payload with both observed and predicted cycles must issue a DELETE targeting
+        ``predicted_cycle = TRUE`` before the upsert.
+
+        :param mock_upsert: Patched upsert_model_instances.
+        :param processor: GarminProcessor fixture.
+        :param mock_session: Mock session fixture.
+        :param temp_dir: Temporary directory fixture.
+        """
+        # Configure the wipe DELETE rowcount so the processor's log line is happy.
+        mock_session.execute.return_value.rowcount = 0
+
+        data = {
+            "cycleSummaries": [
+                {
+                    "startDate": "2026-05-23",
+                    "periodLength": 3,
+                    "predictedCycle": False,
+                },
+                {
+                    "startDate": "2026-06-20",
+                    "periodLength": 5,
+                    "predictedCycle": True,
+                },
+            ]
+        }
+        file_path = temp_dir / "999_MENSTRUAL_CYCLE_SUMMARY_2026-05-25T12-00-00Z.json"
+        with open(file_path, "w", encoding="utf-8") as f:
+            json.dump(data, f)
+
+        processor._process_menstrual_cycle_summary(file_path, mock_session)
+
+        # Verify the wipe DELETE was executed and targets predicted_cycle = TRUE.
+        assert mock_session.execute.call_count == 1
+        delete_stmt = mock_session.execute.call_args.args[0]
+        compiled = delete_stmt.compile(compile_kwargs={"literal_binds": True})
+        sql_text = str(compiled).upper()
+        assert "DELETE FROM" in sql_text
+        assert "MENSTRUAL_CYCLE_SUMMARY" in sql_text
+        assert "PREDICTED_CYCLE" in sql_text
+
+        # Verify the upsert received both records with the right shape.
+        mock_upsert.assert_called_once()
+        kwargs = mock_upsert.call_args.kwargs
+        assert kwargs["conflict_columns"] == ["user_id", "start_date"]
+        assert kwargs["on_conflict_update"] is True
+        records = kwargs["model_instances"]
+        assert len(records) == 2
+        assert all(isinstance(r, MenstrualCycleSummary) for r in records)
+        flags = sorted(r.predicted_cycle for r in records)
+        assert flags == [False, True]
+
+    @patch("dags.pipelines.garmin.process.upsert_model_instances")
+    def test_menstrual_cycle_summary_empty_still_wipes_predicted(
+        self, mock_upsert, processor, mock_session, temp_dir
+    ):
+        """
+        An empty ``cycleSummaries`` payload must still issue the wipe DELETE so stale
+        predictions are cleared, but must NOT call ``upsert_model_instances``.
+
+        :param mock_upsert: Patched upsert_model_instances.
+        :param processor: GarminProcessor fixture.
+        :param mock_session: Mock session fixture.
+        :param temp_dir: Temporary directory fixture.
+        """
+        mock_session.execute.return_value.rowcount = 0
+
+        data = {"cycleSummaries": []}
+        file_path = temp_dir / "999_MENSTRUAL_CYCLE_SUMMARY_2026-05-25T12-00-00Z.json"
+        with open(file_path, "w", encoding="utf-8") as f:
+            json.dump(data, f)
+
+        processor._process_menstrual_cycle_summary(file_path, mock_session)
+
+        # DELETE was issued.
+        assert mock_session.execute.call_count == 1
+        # No upsert call.
+        mock_upsert.assert_not_called()
+
+    @patch("dags.pipelines.garmin.process.upsert_model_instances")
+    def test_menstrual_cycle_summary_skips_entries_without_start_date(
+        self, mock_upsert, processor, mock_session, temp_dir
+    ):
+        """
+        A summary entry missing ``startDate`` is skipped with a warning; valid entries
+        in the same payload still land.
+
+        :param mock_upsert: Patched upsert_model_instances.
+        :param processor: GarminProcessor fixture.
+        :param mock_session: Mock session fixture.
+        :param temp_dir: Temporary directory fixture.
+        """
+        mock_session.execute.return_value.rowcount = 0
+
+        data = {
+            "cycleSummaries": [
+                {
+                    "startDate": "2026-05-23",
+                    "periodLength": 3,
+                    "predictedCycle": False,
+                },
+                # No startDate -- must be skipped.
+                {"periodLength": 5, "predictedCycle": True},
+            ]
+        }
+        file_path = temp_dir / "999_MENSTRUAL_CYCLE_SUMMARY_2026-05-25T12-00-00Z.json"
+        with open(file_path, "w", encoding="utf-8") as f:
+            json.dump(data, f)
+
+        with patch("dags.pipelines.garmin.process.LOGGER.warning") as mock_warn:
+            processor._process_menstrual_cycle_summary(file_path, mock_session)
+
+        mock_upsert.assert_called_once()
+        records = mock_upsert.call_args.kwargs["model_instances"]
+        assert len(records) == 1
+        assert records[0].start_date == date(2026, 5, 23)
+        assert mock_warn.called
 
 
 class TestProcessFitSubSecond:

--- a/tests/dags/pipelines/garmin/test_process.py
+++ b/tests/dags/pipelines/garmin/test_process.py
@@ -105,10 +105,17 @@ class TestGarminProcessor:
         """
         Create mock SQLAlchemy session for testing.
 
+        The default ``session.execute().scalar_one_or_none()`` returns ``None`` so the
+        activity processor's duplicate-detection check (which queries for an existing
+        ``(user_id, start_ts)`` row with a different ``activity_id``) treats the
+        activity as new in mock-based tests. Tests that want to exercise the duplicate
+        path should override this on their session instance.
+
         :return: Mock session.
         """
         session = MagicMock()
         session.execute.return_value.scalars.return_value.first.return_value = None
+        session.execute.return_value.scalar_one_or_none.return_value = None
         session.merge.return_value = None
         session.add.return_value = None
         return session
@@ -1295,6 +1302,210 @@ class TestGarminProcessor:
         assert activity_instance.purposeful is False
         assert activity_instance.favorite is False
         assert activity_instance.pr is False
+
+    # --- Activity base duplicate-dedup tests --------------------------------
+    # Tests for the (user_id, start_ts) duplicate-detection guard in
+    # ``_process_activity_base`` (port of garmin-health-data#67).
+    #
+    # Garmin Connect accepts multiple activities with identical start times
+    # (manual entries, two devices recording the same session, etc.) and
+    # returns each as a distinct ``activityId``. The activity table's
+    # ``UNIQUE (user_id, start_ts)`` constraint correctly rejects the second
+    # insert, but a raw ``IntegrityError`` from the upsert would quarantine
+    # the whole ``(user, day)`` FileSet, losing sleep / HR / stress / etc.
+    # for that day along with the duplicate. The processor detects the
+    # conflict before the upsert, skips the duplicate with a warning, and
+    # keeps processing the rest of the day's data.
+
+    @patch("dags.pipelines.garmin.process.upsert_model_instances")
+    def test_duplicate_start_ts_with_different_activity_id_is_skipped(
+        self, mock_upsert, processor, mock_session
+    ):
+        """
+        A second activity with the same ``(user_id, start_ts)`` as a
+        previously persisted activity (but a different ``activity_id``) must
+        be dropped with a warning: ``_process_activity_base`` returns
+        ``None``, no ``upsert_model_instances`` call is made, and the new
+        ``activity_id`` is registered in ``_skipped_activity_ids`` so
+        downstream per-activity file processors also skip it.
+
+        :param mock_upsert: Mock upsert function.
+        :param processor: GarminProcessor fixture.
+        :param mock_session: Mock session fixture.
+        """
+        # Arrange. Dedup SELECT returns an existing activity_id different
+        # from the one being processed.
+        mock_session.execute.return_value.scalar_one_or_none.return_value = 12345
+
+        activity_data = {
+            "activityId": 99999,  # Distinct from the seeded 12345.
+            "activityName": "Morning Run",
+            "activityType": {"typeId": 1, "typeKey": "running"},
+            "eventType": {"typeId": 1, "typeKey": "other"},
+            "startTimeGMT": "2022-01-01T07:00:00",
+            "startTimeLocal": "2022-01-01T00:00:00",
+            "endTimeGMT": "2022-01-01T08:30:00",
+            "deviceId": 123456789,
+            "manufacturer": "GARMIN",
+            "timeZoneId": 1,
+            "parent": False,
+            "purposeful": True,
+            "favorite": False,
+            "pr": False,
+            "hasPolyline": True,
+            "hasImages": False,
+            "hasVideo": False,
+            "hasSplits": True,
+            "hasHeatMap": False,
+            "elevationCorrected": True,
+            "atpActivity": False,
+            "manualActivity": False,
+            "autoCalcCalories": True,
+        }
+
+        # Act.
+        processor.user_id = 1
+        with patch("dags.lib.logging_utils.LOGGER.warning") as mock_logger:
+            result = processor._process_activity_base(activity_data, mock_session)
+
+        # Assert.
+        # Skip signaled to caller.
+        assert result is None
+        # Warning was logged.
+        mock_logger.assert_called_once()
+        warning_msg = mock_logger.call_args[0][0]
+        assert "Skipping duplicate activity 99999" in warning_msg
+        assert "activity_id=12345" in warning_msg
+        # Duplicate id was registered for child-processor skipping.
+        assert 99999 in processor._skipped_activity_ids
+        # No upsert was attempted for the duplicate.
+        mock_upsert.assert_not_called()
+
+    @patch("dags.pipelines.garmin.process.upsert_model_instances")
+    def test_reextract_same_activity_id_does_not_trip_dedup(
+        self, mock_upsert, processor, mock_session
+    ):
+        """
+        Idempotency guard: re-processing the same ``activity_id`` with the same
+        ``start_ts`` (e.g. a user re-running the extractor) must NOT trip the duplicate
+        path. The existence query excludes rows with the same ``activity_id`` from the
+        conflict set, so the normal UPSERT-by-PK path runs unchanged.
+
+        :param mock_upsert: Mock upsert function.
+        :param processor: GarminProcessor fixture.
+        :param mock_session: Mock session fixture.
+        """
+        # Arrange. Dedup SELECT returns None (no different activity_id
+        # exists at this start_ts), so the upsert path proceeds.
+        mock_session.execute.return_value.scalar_one_or_none.return_value = None
+
+        activity_data = {
+            "activityId": 12345,
+            "activityName": "Morning Run",
+            "activityType": {"typeId": 1, "typeKey": "running"},
+            "eventType": {"typeId": 1, "typeKey": "other"},
+            "startTimeGMT": "2022-01-01T07:00:00",
+            "startTimeLocal": "2022-01-01T00:00:00",
+            "endTimeGMT": "2022-01-01T08:30:00",
+            "deviceId": 123456789,
+            "manufacturer": "GARMIN",
+            "timeZoneId": 1,
+            "parent": False,
+            "purposeful": True,
+            "favorite": False,
+            "pr": False,
+            "hasPolyline": True,
+            "hasImages": False,
+            "hasVideo": False,
+            "hasSplits": True,
+            "hasHeatMap": False,
+            "elevationCorrected": True,
+            "atpActivity": False,
+            "manualActivity": False,
+            "autoCalcCalories": True,
+        }
+
+        mock_activity_with_id = Activity()
+        mock_activity_with_id.activity_id = 12345
+        mock_upsert.return_value = [mock_activity_with_id]
+
+        # Act.
+        processor.user_id = 1
+        result = processor._process_activity_base(activity_data, mock_session)
+
+        # Assert.
+        assert result == 12345
+        assert 12345 not in processor._skipped_activity_ids
+        mock_upsert.assert_called_once()
+
+    def test_fit_file_for_deduped_activity_is_skipped(
+        self, processor, mock_session, temp_dir
+    ):
+        """
+        After ``_process_activity_base`` skips a duplicate, the per-activity file
+        processors must also skip files for that ``activity_id`` instead of FK-failing
+        on the missing parent row. Covers the FIT path: registers the activity_id as
+        skipped, then asserts ``_process_fit_file`` returns early without inserting rows
+        or querying for the activity.
+
+        :param processor: GarminProcessor fixture.
+        :param mock_session: Mock session fixture.
+        :param temp_dir: Temporary directory fixture.
+        """
+        # Arrange.
+        activity_id = 99999
+        processor._skipped_activity_ids.add(activity_id)
+        # Filename pattern: <user_id>_ACTIVITY_<activity_id>_<timestamp>.fit
+        fake_fit = temp_dir / f"1_ACTIVITY_{activity_id}_2024-01-01T08:00:00Z.fit"
+        fake_fit.write_bytes(b"not a real fit file")
+
+        # Act.
+        with patch("dags.lib.logging_utils.LOGGER.warning") as mock_logger:
+            processor._process_fit_file(fake_fit, mock_session)
+
+        # Assert.
+        mock_logger.assert_called_once()
+        warning_msg = mock_logger.call_args[0][0]
+        assert "Skipping FIT file for activity 99999" in warning_msg
+        # No DB queries, no inserts.
+        mock_session.execute.assert_not_called()
+        mock_session.add_all.assert_not_called()
+
+    def test_exercise_sets_for_deduped_activity_is_skipped(
+        self, processor, mock_session, temp_dir
+    ):
+        """
+        Same as the FIT case, for the EXERCISE_SETS path.
+
+        ``_process_exercise_sets`` must skip files whose activity_id was deduped earlier
+        in the same FileSet rather than running the delete+insert and FK-failing on the
+        missing parent row.
+
+        :param processor: GarminProcessor fixture.
+        :param mock_session: Mock session fixture.
+        :param temp_dir: Temporary directory fixture.
+        """
+        # Arrange.
+        activity_id = 99999
+        processor._skipped_activity_ids.add(activity_id)
+        data = {
+            "activityId": activity_id,
+            "exerciseSets": [{"messageIndex": 0, "setType": "ACTIVE"}],
+        }
+        fake_es = temp_dir / f"1_EXERCISE_SETS_{activity_id}_2024-01-01.json"
+        fake_es.write_text(json.dumps(data))
+
+        # Act.
+        with patch("dags.lib.logging_utils.LOGGER.warning") as mock_logger:
+            processor._process_exercise_sets(fake_es, mock_session)
+
+        # Assert.
+        mock_logger.assert_called_once()
+        warning_msg = mock_logger.call_args[0][0]
+        assert "Skipping EXERCISE_SETS for activity 99999" in warning_msg
+        # No deletes, no inserts.
+        mock_session.execute.assert_not_called()
+        mock_session.add_all.assert_not_called()
 
     def test_process_file_set(
         self, processor, mock_session, temp_dir, sample_sleep_data
@@ -6040,8 +6251,13 @@ class TestProcessFitSubSecond:
     def mock_session(self) -> MagicMock:
         """
         Create mock SQLAlchemy session for testing.
+
+        The default ``session.execute().scalar_one_or_none()`` returns ``None`` so the
+        activity processor's duplicate-detection check treats the activity as new in
+        mock-based tests.
         """
         session = MagicMock()
+        session.execute.return_value.scalar_one_or_none.return_value = None
         return session
 
     @pytest.fixture

--- a/tests/dags/pipelines/garmin/test_process.py
+++ b/tests/dags/pipelines/garmin/test_process.py
@@ -1106,9 +1106,12 @@ class TestGarminProcessor:
         processor.user_id = 1
         result = processor._process_activity_base(activity_data, mock_session)
 
-        # Assert: skipped with no upsert call.
+        # Assert: skipped with no upsert call. Activity_id must also be
+        # registered in _skipped_activity_ids so the FIT file processor
+        # short-circuits instead of FK-failing on the missing parent.
         assert result is None
         mock_upsert.assert_not_called()
+        assert 555 in processor._skipped_activity_ids
 
     @patch("dags.pipelines.garmin.process.upsert_model_instances")
     def test_process_activity_base_handles_missing_device_fields(

--- a/tests/dags/pipelines/garmin/test_process.py
+++ b/tests/dags/pipelines/garmin/test_process.py
@@ -1079,6 +1079,38 @@ class TestGarminProcessor:
         assert activity_instance.activity_id == 123456789
 
     @patch("dags.pipelines.garmin.process.upsert_model_instances")
+    def test_process_activity_base_skips_when_end_ts_cannot_be_derived(
+        self, mock_upsert, processor, mock_session
+    ):
+        """
+        When both ``endTimeGMT`` and ``duration`` are missing, the activity has no way
+        to derive ``end_ts`` (a NOT NULL column). The processor must log a warning and
+        return ``None`` rather than raise on ``datetime.fromisoformat(None)``.
+
+        :param mock_upsert: Mock upsert function.
+        :param processor: GarminProcessor fixture.
+        :param mock_session: Mock session fixture.
+        """
+        # Arrange: minimal activity payload with no endTimeGMT and no duration.
+        activity_data = {
+            "activityId": 555,
+            "activityName": "Broken",
+            "activityType": {"typeId": 1, "typeKey": "running"},
+            "eventType": {"typeId": 1, "typeKey": "other"},
+            "startTimeGMT": "2016-01-01T07:00:00",
+            "startTimeLocal": "2016-01-01T00:00:00",
+            # Note: BOTH endTimeGMT and duration are absent.
+        }
+
+        # Act.
+        processor.user_id = 1
+        result = processor._process_activity_base(activity_data, mock_session)
+
+        # Assert: skipped with no upsert call.
+        assert result is None
+        mock_upsert.assert_not_called()
+
+    @patch("dags.pipelines.garmin.process.upsert_model_instances")
     def test_process_activity_base_handles_missing_device_fields(
         self, mock_upsert, processor, mock_session
     ):

--- a/tests/dags/pipelines/garmin/test_process.py
+++ b/tests/dags/pipelines/garmin/test_process.py
@@ -1542,6 +1542,37 @@ class TestGarminProcessor:
         mock_session.execute.assert_not_called()
         mock_session.add_all.assert_not_called()
 
+    def test_process_file_set_resets_skipped_activity_ids(
+        self, processor, mock_session, temp_dir, sample_sleep_data
+    ):
+        """
+        _skipped_activity_ids must be cleared at the start of each FileSet.
+
+        A GarminProcessor instance is reused across FileSets in one batch. Without the
+        reset, activity_ids skipped in one FileSet would leak into the next, causing
+        unrelated activities (e.g. an activity reused on a later day) to be silently
+        dropped and the set to grow unbounded.
+
+        :param processor: GarminProcessor fixture.
+        :param mock_session: Mock session fixture.
+        :param temp_dir: Temporary directory fixture.
+        :param sample_sleep_data: Sample sleep data fixture (any valid file content).
+        """
+        # Arrange: pre-populate the skip set as if a previous FileSet had filled it.
+        processor._skipped_activity_ids.add(99999)
+        sleep_file = temp_dir / "123456789_SLEEP_2022-01-01T00-00-00Z.json"
+        with open(sleep_file, "w", encoding="utf-8") as f:
+            json.dump(sample_sleep_data, f)
+        file_set = FileSet(files={GARMIN_FILE_TYPES.SLEEP: [sleep_file]})
+        mock_session.execute.return_value.scalars.return_value.first.return_value = None
+
+        # Act.
+        with patch.object(processor, "_process_sleep"):
+            processor.process_file_set(file_set, mock_session)
+
+        # Assert: skip set was cleared (the 99999 from the prior FileSet is gone).
+        assert processor._skipped_activity_ids == set()
+
     def test_process_file_set(
         self, processor, mock_session, temp_dir, sample_sleep_data
     ):


### PR DESCRIPTION
## Summary

Bundled port of three `garmin-health-data` PRs to openetl's Garmin pipeline. Three commits, one PR.

- **#67** — `fix(process): skip duplicate (user_id, start_ts) activities`. The `activity` table's `UNIQUE(user_id, start_ts)` is a sensible invariant Garmin Connect itself doesn't enforce (users can create two activities with the same start time). Pre-port the second insert raised `IntegrityError` and quarantined the whole `(user, day)` FileSet, losing sleep / HR / stress / etc. for that day. Now `_process_activity_base` SELECT-checks for a different `activity_id` at the same `(user_id, start_ts)`, logs a yellow-equivalent warning, registers the id in `self._skipped_activity_ids`, and returns `None`. Child processors (`_process_exercise_sets`, `_process_fit_file`) honor the skip set.

- **#65** — `feat(extract): RANGE-per-window extraction + PER_ACTIVITY taxonomy`. RANGE-typed data (`BODY_COMPOSITION`, `ACTIVITIES_LIST`) was previously extracted day-by-day with `startdate=enddate`: N API calls and N near-identical files for an N-day window. Now `_extract_range` issues one API call for the whole window. Splittable responses are split per-day downstream so the processor's `(user, day)` FileSet abstraction stays unchanged. Unsplittable RANGE types (currently used by `MENSTRUAL_CYCLE_SUMMARY` from the next commit) are written as one file stamped `end_date`. A new `PER_ACTIVITY` enum value in `APIMethodTimeParam` replaces the previous name-based `ACTIVITY` / `EXERCISE_SETS` short-circuit with a clean dispatcher branch. Added a parametric test guarding against missing `GarminClient` delegators (catches the class of bug surfaced in upstream PR #63).

- **#64** — `feat(garmin): menstrual cycle day and summary extraction`. Adds two new Garmin data types from the periodic-health service:
  - `MENSTRUAL_CYCLE_DAY` (DAILY): per-day log from dayview (phase, day-in-cycle, period length, predicted cycle length, flow, sex drive, sexual activity, notes, ovulation flag, plus symptoms / moods / discharge tags).
  - `MENSTRUAL_CYCLE_SUMMARY` (RANGE): per-cycle summaries from calendar (observed + Garmin's projections). Calendar API wrapper paginates >92-day ranges in chunks of `MENSTRUAL_CALENDAR_MAX_DAYS - 1` and dedupes by `startDate` (later chunk wins, freshest projection kept).

  Three new tables in the `garmin.` schema: `menstrual_cycle_day`, `menstrual_cycle_tag` (polymorphic for the three tag kinds, CASCADE-deleted via composite FK), `menstrual_cycle_summary`. Three distinct write semantics:
  - Day rows: UPSERT by `(user_id, date)`.
  - Tags: delete-then-reinsert per `(user_id, date)` because users can REMOVE tags between extracts; a pure UPSERT would leave orphan rows.
  - Summaries: real cycles UPSERT by `(user_id, start_date)`; predicted cycles wipe-and-replace on every extract because Garmin's projection dates shift between runs (the wipe DELETE fires even on empty payloads, so stale predictions clear).

## Adaptations from garmin-health-data

- SQLite → PostgreSQL (TIMESTAMPTZ, BOOLEAN, `DEFAULT NOW()`, schema-qualified FKs).
- Raw SQLite session → SQLAlchemy ORM with `upsert_model_instances` from `dags.lib.sql_utils`.
- `click.secho(..., fg="yellow")` → `LOGGER.warning(...)`.
- Tests adapted from real-SQLite to MagicMock-based pattern (openetl convention).
- No TCX processor (openetl doesn't have one).
- No PyPI version bump / CHANGELOG hunks.

## Test plan

- [x] All three commits individually green (per-commit test counts: 350 / 372 / 382).
- [x] `make check-format` clean on HEAD.
- [x] 382 garmin tests pass on HEAD.
- [x] Delegator-coverage parametric test runs 18 cases (16 + 2 new).
- [x] Each commit individually revertable.
- [x] Three new tests for activity dedup + child propagation.
- [x] Six new tests for RANGE-per-window + splitter behavior + delegator coverage.
- [x] Seven new tests for menstrual processor (day upsert + phase translation + tag delete-then-insert + predicted-cycle wipe-and-replace).
- [ ] DDL not yet applied to the lens database; deploy step required before the new data types can ingest.
- [ ] End-to-end test against a real Garmin account pending deployment.

## Out of scope

- Sleep table dedup (the same UNIQUE constraint exists on `garmin.sleep` but is not mirrored; can be added later if it bites).
- Per-day file splitter generalization to a registry (kept as name-based if/elif for now; one-off symmetry would be premature).